### PR TITLE
Update README.md `node install` updated to `yarn install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You may need an appropriate loader to handle this file type, currently no loader
  @ dll renderer renderer[0]
 ```
 
-You will need to manually remove the file `./node_modules/node-gyp/lib/Find-VisualStudio.cs`, then re-run `node install`. We'll work on finding a long-term fix for this.
+You will need to manually remove the file `./node_modules/node-gyp/lib/Find-VisualStudio.cs`, then re-run `yarn install`. We'll work on finding a long-term fix for this.
 
 If when building/packaging you get the following error:
 


### PR DESCRIPTION
**This pull request addresses a typo in the README.md file, correcting the instruction to run node install to the appropriate command yarn install. The incorrect instruction could potentially confuse users attempting to install project dependencies using Yarn, as the incorrect command would not produce the desired result. This PR ensures accurate and actionable instructions for users, enhancing the usability and reliability of our project documentation.**


![image](https://github.com/StatTag/StatWrap/assets/122719607/db0b01ba-6baf-4015-a8eb-ca811fed8716)
