### PR TITLE
(Fix) : Fixed [Webpack] configuration to handle .cs files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,27 +36,7 @@ yarn package
 
 ## Build Issues
 
-There are some potential build issues that we need to fix long-term, but have temporary workarounds. If after running `yarn install` you get an error:
-
-```
-ERROR in ./node_modules/node-gyp/lib/Find-VisualStudio.cs 9:6
-Module parse failed: Unexpected token (9:6)
-You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-| // This script needs to be compatible with PowerShell v2 to run on Windows 2008R2 and Windows 7.
-|
-> using System;
-| using System.Text;
-| using System.Runtime.InteropServices;
- @ ./node_modules/node-gyp/lib/ sync ^\.\/.*$ ./Find-VisualStudio.cs
- @ ./node_modules/node-gyp/lib/node-gyp.js 41:13-36 195:36-53
- @ ./node_modules/@electron/rebuild/lib/src/module-type/node-gyp.js 9:35-54
- @ ./node_modules/@electron/rebuild/lib/src/module-rebuilder.js 34:19-52
- @ ./node_modules/@electron/rebuild/lib/src/rebuild.js 38:27-56
- @ ./node_modules/@electron/rebuild/lib/src/main.js 4:18-38
- @ dll renderer renderer[0]
-```
-
-You will need to manually remove the file `./node_modules/node-gyp/lib/Find-VisualStudio.cs`, then re-run `yarn install`. We'll work on finding a long-term fix for this.
+There are some potential build issues that we need to fix long-term, but have temporary workarounds.
 
 If when building/packaging you get the following error:
 

--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -12,7 +12,7 @@ export default {
   module: {
     rules: [
       {
-        test: /\.jsx?$/,
+        test: /\.(jsx?|cs)$/,
         exclude: /node_modules/,
         use: {
           loader: 'babel-loader',

--- a/internals/scripts/CheckYarn.js
+++ b/internals/scripts/CheckYarn.js
@@ -6,12 +6,3 @@ if (!/yarn\.js$/.test(process.env.npm_execpath || '')) {
     "\u001b[33mYou don't seem to be using yarn. This could produce unexpected results.\u001b[39m"
   );
 }
-
-// We have experienced this issue for some time with this file and our setup not behaving.  The
-// best solution discovered is to remove the file.  Not great, but if it works, we'll do it.
-// TODO - Eventually figure out what's really going on, see if we can update the stack to resolve
-// this, or something else.
-const problemFile = './node_modules/node-gyp/lib/Find-VisualStudio.cs';
-if (fs.existsSync(problemFile)) {
-  fs.unlinkSync(problemFile);
-}


### PR DESCRIPTION
# Summary of Changes

Configured webpack to handle `.cs` files appropriately by adding a loader configuration for `.cs` files in `webpack.config.base.js`. This change might serve as a permanent solution for one of the potential build issues that we wanted to fix for long-term.

## Related Issue

Closes #157 

## Checklist

- [x] My code is well-documented, and I've updated relevant documentation.
- [x] I have tested these changes on my local environment.
- [x] I have reviewed and proofread my code and the changes.
- [x] The branch is up-to-date with the base branch.

## Additional Context

I also edited `readme.md` file and added information about this build issue as it will no longer exist after this PR. Also, I edited `CheckYarn.js` file and removed the check for the `problemFile` from the file as that checks if `./node_modules/node-gyp/lib/Find-VisualStudio.cs` exists or not; this is also no longer needed.

## Reviewer(s)

@lrasmus