### PR TITLE
Fixes #157 - webpack error during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,27 +36,7 @@ yarn package
 
 ## Build Issues
 
-There are some potential build issues that we need to fix long-term, but have temporary workarounds. If after running `yarn install` you get an error:
-
-```
-ERROR in ./node_modules/node-gyp/lib/Find-VisualStudio.cs 9:6
-Module parse failed: Unexpected token (9:6)
-You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-| // This script needs to be compatible with PowerShell v2 to run on Windows 2008R2 and Windows 7.
-|
-> using System;
-| using System.Text;
-| using System.Runtime.InteropServices;
- @ ./node_modules/node-gyp/lib/ sync ^\.\/.*$ ./Find-VisualStudio.cs
- @ ./node_modules/node-gyp/lib/node-gyp.js 41:13-36 195:36-53
- @ ./node_modules/@electron/rebuild/lib/src/module-type/node-gyp.js 9:35-54
- @ ./node_modules/@electron/rebuild/lib/src/module-rebuilder.js 34:19-52
- @ ./node_modules/@electron/rebuild/lib/src/rebuild.js 38:27-56
- @ ./node_modules/@electron/rebuild/lib/src/main.js 4:18-38
- @ dll renderer renderer[0]
-```
-
-You will need to manually remove the file `./node_modules/node-gyp/lib/Find-VisualStudio.cs`, then re-run `yarn install`. We'll work on finding a long-term fix for this.
+There are some potential build/packaging issues that we need to fix long-term, but have temporary workarounds.
 
 If when building/packaging you get the following error:
 
@@ -107,7 +87,7 @@ You will need to ensure Python 2.7 is available. This is required (for now) by t
 ```
 pyenv install 2.7.18
 export PYTHON_PATH=$HOME/.pyenv/versions/2.7.18/bin/python
-yarn run build
+yarn package
 ```
 
 _(Solution courtesy of: https://github.com/marktext/marktext/issues/3175#issuecomment-1208840633)_

--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -7,7 +7,8 @@ import webpack from 'webpack';
 import { dependencies as externals } from '../app/package.json';
 
 export default {
-  externals: [...Object.keys(externals || {})],
+  // Explicitly exclude node-gyp.  This causes some issues on macOS otherwise when yarn install is run.
+  externals: ['node-gyp', ...Object.keys(externals || {})],
 
   module: {
     rules: [

--- a/internals/scripts/CheckYarn.js
+++ b/internals/scripts/CheckYarn.js
@@ -1,17 +1,7 @@
 // @flow
-const fs = require('fs');
 
 if (!/yarn\.js$/.test(process.env.npm_execpath || '')) {
   console.warn(
     "\u001b[33mYou don't seem to be using yarn. This could produce unexpected results.\u001b[39m"
   );
-}
-
-// We have experienced this issue for some time with this file and our setup not behaving.  The
-// best solution discovered is to remove the file.  Not great, but if it works, we'll do it.
-// TODO - Eventually figure out what's really going on, see if we can update the stack to resolve
-// this, or something else.
-const problemFile = './node_modules/node-gyp/lib/Find-VisualStudio.cs';
-if (fs.existsSync(problemFile)) {
-  fs.unlinkSync(problemFile);
 }


### PR DESCRIPTION
(Hopefully) addresses the webpack error that happens when `yarn install` is run

Thanks to @Abhijay007 for an earlier draft fix which pointed me in this direction of investigation.