### PR TITLE
(Fix): Updated incorrect "Learn More" Link

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -142,7 +142,7 @@ export default class MenuBuilder {
         {
           label: 'Learn More',
           click() {
-            shell.openExternal('https://sites.northwestern.edu/stattag/');
+            shell.openExternal('https://sites.northwestern.edu/statwrap/');
           }
         },
         {

--- a/app/menu.js
+++ b/app/menu.js
@@ -226,7 +226,7 @@ export default class MenuBuilder {
           {
             label: 'Learn More',
             click() {
-              shell.openExternal('https://sites.northwestern.edu/stattag/');
+              shell.openExternal('https://sites.northwestern.edu/statwrap/');
             }
           },
           {


### PR DESCRIPTION
# Summary of Changes

Updated the links in the "learn more"  section of the Statwrap application's help section to accurately direct users to resources specific to StatWrap :

- "Learn More" link updated to: https://sites.northwestern.edu/statwrap/

## Related Issue

Closes #162

## Checklist

- [x] I have tested these changes on my local environment.
- [x] I have reviewed and proofread my code and the changes.
- [x] The branch is up-to-date with the base branch.

## Reviewer(s)

@lrasmus