### PR TITLE
(Feat) : Added +/- zoom control buttons for Workflow view 

### DIFF
--- a/app/components/Workflow/DependencyGraph/DependencyGraphEChart.js
+++ b/app/components/Workflow/DependencyGraph/DependencyGraphEChart.js
@@ -1,4 +1,3 @@
-// import { style } from 'd3-selection';
 import React, { useState, useEffect } from 'react';
 import ReactECharts from 'echarts-for-react';
 import WorkflowUtil from '../../../utils/workflow';
@@ -21,10 +20,6 @@ const ICON_TYPES = {
   FIGURE: `${ICON_PATH}figure.svg`
 };
 
-/**
- * Component that renders a code file
- * @param {Object} props component props to render.
- */
 function getIcon(node) {
   let iconUrl = ICON_TYPES.GENERIC;
   if (node.value === 'python') {
@@ -45,13 +40,12 @@ function getIcon(node) {
   return iconUrl;
 }
 
-const dependencyGraphEChart = props => {
-  const { assets } = props;
+const DependencyGraphEChart = props => {
+  const { assets, zoomLevel } = props;
   const [graphData, setGraphData] = useState(null);
-  // The actual contents of the filter (no filter by default)
   const [filter, setFilter] = useState([]);
 
-  const resetFilter = () => {
+  const resetGraph = () => {
     if (assets) {
       const filteredAssets = AssetUtil.filterIncludedFileAssets(assets);
       setFilter(ProjectUtil.getWorkflowFilters(filteredAssets));
@@ -62,22 +56,20 @@ const dependencyGraphEChart = props => {
   };
 
   useEffect(() => {
-    resetFilter();
+    resetGraph();
   }, [assets]);
 
-  // Whenever the filter changes, update the list of assets to include only
-  // those that should be displayed.
   const handleFilterChanged = updatedFilter => {
     if (assets) {
       setFilter(updatedFilter);
-      setGraphData(WorkflowUtil.getAllDependenciesAsEChartGraph(assets, filter));
+      setGraphData(WorkflowUtil.getAllDependenciesAsEChartGraph(assets, updatedFilter));
     } else {
       setGraphData(null);
     }
   };
 
   const handleFilterReset = () => {
-    resetFilter();
+    resetGraph();
   };
 
   let graph = null;
@@ -93,7 +85,7 @@ const dependencyGraphEChart = props => {
           }
           return `${params.data.fullName}`;
         },
-        confine: 'true',
+        confine: true,
         textStyle: {
           overflow: 'breakAll',
           width: 200
@@ -104,6 +96,7 @@ const dependencyGraphEChart = props => {
           type: 'graph',
           layout: 'force',
           roam: true,
+          zoom: zoomLevel, // Apply zoom level
           label: {
             show: true,
             position: 'right',
@@ -120,6 +113,7 @@ const dependencyGraphEChart = props => {
     };
     graph = <ReactECharts option={option} style={{ height: '100%', width: '100%' }} />;
   }
+
   return (
     <div className={styles.container}>
       <div className={styles.filter}>
@@ -135,4 +129,4 @@ const dependencyGraphEChart = props => {
   );
 };
 
-export default dependencyGraphEChart;
+export default DependencyGraphEChart;

--- a/app/components/Workflow/DependencyGraph/DependencyGraphEChart.js
+++ b/app/components/Workflow/DependencyGraph/DependencyGraphEChart.js
@@ -1,3 +1,4 @@
+// import { style } from 'd3-selection';
 import React, { useState, useEffect } from 'react';
 import ReactECharts from 'echarts-for-react';
 import WorkflowUtil from '../../../utils/workflow';
@@ -19,6 +20,11 @@ const ICON_TYPES = {
   DATA: `${ICON_PATH}data.svg`,
   FIGURE: `${ICON_PATH}figure.svg`
 };
+
+/**
+ * Component that renders a code file
+ * @param {Object} props component props to render.
+ */
 
 function getIcon(node) {
   let iconUrl = ICON_TYPES.GENERIC;
@@ -45,7 +51,7 @@ const DependencyGraphEChart = props => {
   const [graphData, setGraphData] = useState(null);
   const [filter, setFilter] = useState([]);
 
-  const resetGraph = () => {
+  const resetFilter = () => {
     if (assets) {
       const filteredAssets = AssetUtil.filterIncludedFileAssets(assets);
       setFilter(ProjectUtil.getWorkflowFilters(filteredAssets));
@@ -56,20 +62,22 @@ const DependencyGraphEChart = props => {
   };
 
   useEffect(() => {
-    resetGraph();
+    resetFilter();
   }, [assets]);
 
+  // Whenever the filter changes, update the list of assets to include only
+  // those that should be displayed.
   const handleFilterChanged = updatedFilter => {
     if (assets) {
       setFilter(updatedFilter);
-      setGraphData(WorkflowUtil.getAllDependenciesAsEChartGraph(assets, updatedFilter));
+      setGraphData(WorkflowUtil.getAllDependenciesAsEChartGraph(assets, filter));
     } else {
       setGraphData(null);
     }
   };
 
   const handleFilterReset = () => {
-    resetGraph();
+    resetFilter();
   };
 
   let graph = null;

--- a/app/components/Workflow/Workflow.css
+++ b/app/components/Workflow/Workflow.css
@@ -3,12 +3,10 @@
   height: 100%;
 }
 
-
 .header {
   display: flex;
   align-items: center;
 }
-
 
 .buttonsWrapper {
   margin-left: auto;
@@ -16,16 +14,14 @@
   align-items: center;
 }
 
-
 button {
-  background-color: #ffffff;
+  background-color: #fff;
   border: 1px solid #ccc;
   border-radius: 5px;
   padding: 5px 10px;
   cursor: pointer;
   margin-right: 5px;
 }
-
 
 .projectPath {
   font-size: 0.9rem;

--- a/app/components/Workflow/Workflow.css
+++ b/app/components/Workflow/Workflow.css
@@ -3,9 +3,31 @@
   height: 100%;
 }
 
+
+.header {
+  display: flex;
+  align-items: center;
+}
+
+
+.buttonsWrapper {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+}
+
+
+button {
+  background-color: #ffffff;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  padding: 5px 10px;
+  cursor: pointer;
+  margin-right: 5px;
+}
+
+
 .projectPath {
   font-size: 0.9rem;
   margin-left: 30px;
-  display: inline-flex;
-  vertical-align: middle;
 }

--- a/app/components/Workflow/Workflow.js
+++ b/app/components/Workflow/Workflow.js
@@ -48,8 +48,12 @@ const Workflow = props => {
           {project.path}
         </span>
         <span className={styles.buttonsWrapper}>
-          <button onClick={handleZoomIn}>Zoom In</button>
-          <button onClick={handleZoomOut}>Zoom Out</button>
+          {diagram !== 'tree' && (
+            <>
+              <button onClick={handleZoomIn}>Zoom In</button>
+              <button onClick={handleZoomOut}>Zoom Out</button>
+            </>
+          )}
         </span>
       </div>
       {graph}

--- a/app/components/Workflow/Workflow.js
+++ b/app/components/Workflow/Workflow.js
@@ -1,20 +1,31 @@
 import { ToggleButtonGroup, ToggleButton } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
 import DependencyGraph from './DependencyGraph/DependencyGraphEChart';
 import DependencyTree from './DependencyTree/DependencyTreeEChart';
 import styles from './Workflow.css';
 
-const workflow = props => {
-  const [diagram, setDiagram] = React.useState('graph');
+const Workflow = props => {
+  const [diagram, setDiagram] = useState('graph');
+  const [zoomLevel, setZoomLevel] = useState(1);
 
   const handleDiagram = (event, newDiagram) => {
     setDiagram(newDiagram);
   };
+
+  const handleZoomIn = () => {
+    setZoomLevel(prevZoom => prevZoom * 1.2);
+  };
+
+  const handleZoomOut = () => {
+    setZoomLevel(prevZoom => prevZoom / 1.2);
+  };
+
   const { project } = props;
-  let graph = <DependencyGraph assets={project.assets} />;
+  let graph = <DependencyGraph assets={project.assets} zoomLevel={zoomLevel} />;
   if (diagram === 'tree') {
     graph = <DependencyTree assets={project.assets} />;
   }
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>
@@ -36,10 +47,14 @@ const workflow = props => {
           <br />
           {project.path}
         </span>
+        <span className={styles.buttonsWrapper}>
+          <button onClick={handleZoomIn}>Zoom In</button>
+          <button onClick={handleZoomOut}>Zoom Out</button>
+        </span>
       </div>
       {graph}
     </div>
   );
 };
 
-export default workflow;
+export default Workflow;


### PR DESCRIPTION
# Summary of Changes

Implemented 'Zoom In' and 'Zoom Out' buttons for controlling DependencyGraph zoom, offering an alternative method alongside mouse scrolling.

## Related Issue

Closes #166 

## Checklist

- [x] My code is well-documented, and I've updated relevant documentation.
- [x] I have tested these changes on my local environment.
- [x] I have reviewed and proofread my code and the changes.
- [x] The branch is up-to-date with the base branch.

## Additional Context

https://github.com/StatTag/StatWrap/assets/64387054/13526fdc-153c-46f8-bb0b-d6db3edea3dd

## Reviewer(s)

@lrasmus