### PR TITLE
(Fix) : Added User Specific Time zone to Project logger

### DIFF
--- a/app/components/ProjectLog/ProjectLog.js
+++ b/app/components/ProjectLog/ProjectLog.js
@@ -134,10 +134,22 @@ const projectLog = props => {
   let contents = <div className={styles.empty}>There are no actions or notifications to show</div>;
   if (feed) {
     // eslint-disable-next-line prettier/prettier
-    const dataSource = (updates && updates.log && filterWhatsNew) ? updates.log : feed;
+    const dataSource = updates && updates.log && filterWhatsNew ? updates.log : feed;
+    const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
     const data = dataSource
       .map(f => {
-        return { ...f, datetime: GeneralUtil.formatDateTime(f.timestamp) };
+        const localDateTime = new Date(f.timestamp).toLocaleString(undefined, {
+          timeZone: userTimeZone,
+          weekday: 'short',
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: 'numeric',
+          second: 'numeric'
+        });
+        return { ...f, datetime: localDateTime };
       })
       .filter(
         f =>


### PR DESCRIPTION
# Summary of Changes

This pull request aims to enhance the display of timestamps in the Project Log by automatically formatting them according to the user's local time zone.

**Changes:**

- Modified the code to automatically detect the user's time zone.
- Updated the mapping of timestamps in the `dataSource` to format them according to the user's local time zone.

## Related Issue

Closes #172  

## Checklist

- [x] My code is well-documented, and I've updated relevant documentation.
- [x] I have tested these changes on my local environment.
- [x] I have reviewed and proofread my code and the changes.
- [x] The branch is up-to-date with the base branch.

## Additional Context

![image](https://github.com/StatTag/StatWrap/assets/64387054/27824c91-f674-4d3b-9fd3-5ad54c6e2e31)

## Reviewer(s)

@lrasmus