### PR TITLE
ui: improved ui for note editing \n Clickable area for editing notes …

### DIFF
--- a/app/components/EditableLabel/EditableLabel.js
+++ b/app/components/EditableLabel/EditableLabel.js
@@ -146,10 +146,9 @@ export default class EditableLabel extends React.Component {
       ? this.state.text
       : this.props.labelPlaceHolder || DEFAULT_LABEL_PLACEHOLDER;
     return (
-      <div className={this.props.containerClassName}>
+      <div className={this.props.containerClassName} onClick={this.handleFocus}>
         <label
           className={this.props.labelClassName}
-          onClick={this.handleFocus}
           style={{
             fontSize: this.props.labelFontSize,
             fontWeight: this.props.labelFontWeight


### PR DESCRIPTION
Clickable area for editing notes or creating new notes was only on the text area. Modified it to include the text box.
Fixes: #176