### PR TITLE
⚙️ Fixes dependency tree-view

### DIFF
--- a/app/components/Workflow/DependencyTree/DependencyTree.css
+++ b/app/components/Workflow/DependencyTree/DependencyTree.css
@@ -1,10 +1,15 @@
-.container {
-  width: 100%;
-  height: 75vh;
+.node__root > circle {
+  stroke-width: 9px;
+  stroke:maroon;
+  fill:pink;
 }
 
-.container svg {
-  width: inherit !important;
-  height: inherit !important;
-  position: fixed;
+.node__branch > circle {
+  fill:dodgerblue;
+}
+
+.node__leaf > circle {
+  stroke-width: 8px;
+  stroke:darkslategrey;
+  fill:rgb(174, 209, 174);
 }

--- a/app/components/Workflow/DependencyTree/DependencyTree.css
+++ b/app/components/Workflow/DependencyTree/DependencyTree.css
@@ -1,3 +1,14 @@
+.container {
+  width: 100%;
+  height: 75vh;
+}
+
+.container svg {
+  width: inherit !important;
+  height: inherit !important;
+  position: fixed;
+}
+
 .node__root > circle {
   stroke-width: 9px;
   stroke:maroon;

--- a/app/components/Workflow/DependencyTree/DependencyTreeD3.js
+++ b/app/components/Workflow/DependencyTree/DependencyTreeD3.js
@@ -1,25 +1,40 @@
 import React from 'react';
 import Tree from 'react-d3-tree';
 import WorkflowUtil from '../../../utils/workflow';
-import CodeNode from '../DependencyGraph/CustomNodes/Code/CodeNode';
+import AssetUtil from '../../../utils/asset';
 import styles from './DependencyTree.css';
 
-const renderCodeNode = node => (
-  <CodeNode
-    renderType="svg"
-    node={{ name: node.nodeDatum.name, assetType: node.nodeDatum.attributes.assetType }}
-  />
-);
-
-const dependencyGraphD3 = props => {
+const dependencyGraphD3 = (props) => {
   const { assets } = props;
 
-  const data = WorkflowUtil.getAllDependenciesAsTree(assets);
+  const data = WorkflowUtil.getAllDependenciesAsTree(AssetUtil.filterIncludedFileAssets(assets));
   let tree = null;
   if (data) {
-    tree = <Tree data={data} renderCustomNodeElement={renderCodeNode} />;
+    tree = (
+      <Tree
+        data={data}
+        initialDepth={2}
+        depthFactor={750}
+        separation={{
+          siblings: 0.4,
+          nonSiblings: 0.8,
+        }}
+        dimensions={{ height: window.innerHeight / 2, width: (2 * window.innerWidth) / 3 }}
+        pathFunc={'step'}
+        zoom={0.4}
+        scaleExtent={{ max: 2, min: 0.1 }}
+        translate={{ x: 10, y: window.innerHeight / 3 }}
+        rootNodeClassName={styles.node__root}
+        branchNodeClassName={styles.node__branch}
+        leafNodeClassName={styles.node__leaf}
+      />
+    );
   }
-  return <div className={styles.container}>{tree}</div>;
+  return (
+    <div style={{ width: '100%', height: '75vh', fontSize: '2.1em', fontFamily: 'monospace' }}>
+      {tree}
+    </div>
+  );
 };
 
 export default dependencyGraphD3;

--- a/app/components/Workflow/DependencyTree/DependencyTreeEChart.js
+++ b/app/components/Workflow/DependencyTree/DependencyTreeEChart.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactECharts from 'echarts-for-react';
+import Tree from 'react-d3-tree';
 import WorkflowUtil from '../../../utils/workflow';
 import AssetUtil from '../../../utils/asset';
 import styles from './DependencyTree.css';
@@ -10,36 +10,31 @@ const dependencyGraphEChart = props => {
   const data = WorkflowUtil.getAllDependenciesAsTree(AssetUtil.filterIncludedFileAssets(assets));
   let tree = null;
   if (data) {
-    const option = {
-      tooltip: {
-        trigger: 'item',
-        triggerOn: 'mousemove'
-      },
-      series: [
-        {
-          type: 'tree',
-          id: 0,
-          name: 'tree1',
-          data: [data],
-          edgeShape: 'polyline',
-          edgeForkPosition: '63%',
-          initialTreeDepth: 2,
-          label: {
-            position: 'left',
-            align: 'right'
-          },
-          leaves: {
-            label: {
-              position: 'right',
-              align: 'left'
-            }
-          }
-        }
-      ]
-    };
-    tree = <ReactECharts option={option} style={{ height: '100%', width: '100%' }} />;
+    tree = (
+      <Tree
+        data={data}
+        initialDepth={2}
+        depthFactor={750}
+        separation={{
+          siblings: 0.4,
+          nonSiblings: 0.8,
+        }}
+        dimensions={{ height: window.innerHeight / 2, width: (2 * window.innerWidth) / 3 }}
+        pathFunc={'step'}
+        zoom={0.4}
+        scaleExtent={{ max: 2, min: 0.1 }}
+        translate={{ x: 10, y: window.innerHeight / 3 }}
+        rootNodeClassName={styles.node__root}
+        branchNodeClassName={styles.node__branch}
+        leafNodeClassName={styles.node__leaf}
+      />
+    );
   }
-  return <div className={styles.container}>{tree}</div>;
+  return (
+    <div style={{ width: '100%', height: '75vh', fontSize: '2.1em', fontFamily: 'monospace' }}>
+      {tree}
+    </div>
+  );
 };
 
 export default dependencyGraphEChart;

--- a/app/components/Workflow/DependencyTree/DependencyTreeEChart.js
+++ b/app/components/Workflow/DependencyTree/DependencyTreeEChart.js
@@ -1,40 +1,45 @@
 import React from 'react';
-import Tree from 'react-d3-tree';
+import ReactECharts from 'echarts-for-react';
 import WorkflowUtil from '../../../utils/workflow';
 import AssetUtil from '../../../utils/asset';
 import styles from './DependencyTree.css';
 
-const dependencyGraphEChart = props => {
+const dependencyGraphEChart = (props) => {
   const { assets } = props;
 
   const data = WorkflowUtil.getAllDependenciesAsTree(AssetUtil.filterIncludedFileAssets(assets));
   let tree = null;
   if (data) {
-    tree = (
-      <Tree
-        data={data}
-        initialDepth={2}
-        depthFactor={750}
-        separation={{
-          siblings: 0.4,
-          nonSiblings: 0.8,
-        }}
-        dimensions={{ height: window.innerHeight / 2, width: (2 * window.innerWidth) / 3 }}
-        pathFunc={'step'}
-        zoom={0.4}
-        scaleExtent={{ max: 2, min: 0.1 }}
-        translate={{ x: 10, y: window.innerHeight / 3 }}
-        rootNodeClassName={styles.node__root}
-        branchNodeClassName={styles.node__branch}
-        leafNodeClassName={styles.node__leaf}
-      />
-    );
+    const option = {
+      tooltip: {
+        trigger: 'item',
+        triggerOn: 'mousemove',
+      },
+      series: [
+        {
+          type: 'tree',
+          id: 0,
+          name: 'tree1',
+          data: [data],
+          edgeShape: 'polyline',
+          edgeForkPosition: '63%',
+          initialTreeDepth: 2,
+          label: {
+            position: 'left',
+            align: 'right',
+          },
+          leaves: {
+            label: {
+              position: 'right',
+              align: 'left',
+            },
+          },
+        },
+      ],
+    };
+    tree = <ReactECharts option={option} style={{ height: '100%', width: '100%' }} />;
   }
-  return (
-    <div style={{ width: '100%', height: '75vh', fontSize: '2.1em', fontFamily: 'monospace' }}>
-      {tree}
-    </div>
-  );
+  return <div className={styles.container}>{tree}</div>;
 };
 
 export default dependencyGraphEChart;


### PR DESCRIPTION
# Changes Summary
This PR aims to make the Dependency Tree View tidy and render it free from unwanted UI glitches. As discussed in the issue #182, it was not properly retracting for open branches.
After confirming that the issue was with the tree rendering package, which was unable to deal with the complex data generated by StatWrap, and not the `data` object itself, I explored some npm packages which MIT (or Apache2) license, namely [@carbon/charts-react](https://www.npmjs.com/package/@carbon/charts-react), [gojs](https://www.npmjs.com/package/gojs) & [react-d3-tree](https://www.npmjs.com/package/react-d3-tree), etc.
The first one didn't offer much control over the UI for tree-view, gojs didn't quite fit into how we render the data and the code format, so, I went with this d3-tree which worked quite well and fit better than the earlier one, which I later came to know while noticing no changes in the package.json, that this was earlier used to render the dependency tree as well :)) 
Which left me trying to render the old one, but it was not properly setup so, the view was cluttered at a corner.
I'd thus like to clean that up, as now it's of no use, if you allow.

Styling and color-scheme used was upto my color-sense which I don't think is good enough :) The prop values are set by trial and testing the UI, so, I'd suggest you to modify these with what looks better to you.

## Attachments
![Screenshot from 2024-03-15 03-22-36](https://github.com/StatTag/StatWrap/assets/96688318/ca356d43-4f7b-435f-ad9d-18c8620de61c)
_Initial view for depth 2._
![Screenshot from 2024-03-15 03-22-48](https://github.com/StatTag/StatWrap/assets/96688318/fa915262-d322-4544-a7fd-e197e24a9e0a)
_When the app branch is closed with backend branch open._
![Screenshot from 2024-03-15 03-23-00](https://github.com/StatTag/StatWrap/assets/96688318/cee7d6b7-6f6c-4568-8f13-23d16cee9dde)
_When the backend branch is closed with app branch open._

ScreenRec isn't currently working, transition is looking quite decent. Will try to attach it as well though, later.

## Related Issue 🐛 
Closes #182 

## Checklist ✅ 
- [x] Confirmed that the issue lies with the echarts package, and not the data generated by StatWrap.
- [x] Tree is functioning alright, with smooth transition animations of contraction, expansion, focus & zoom.
- [x] I have tested all the changes locally.

## Reviewer
@lrasmus 