### PR TITLE
(Fix) : Fixed Fontawesome Dependency Compatibility Issue in Statwrap Project Preview

### DIFF
--- a/app/components/ProjectTemplatePreview/ProjectTemplatePreview.js
+++ b/app/components/ProjectTemplatePreview/ProjectTemplatePreview.js
@@ -2,16 +2,29 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import CheckboxTree from 'react-checkbox-tree';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faFolder,
+  faFile,
+  faChevronRight,
+  faChevronDown,
+  faFolderOpen,
+} from '@fortawesome/free-solid-svg-icons';
 import styles from './ProjectTemplatePreview.css';
 
 function contentsToNodes(assets) {
   if (assets) {
-    return assets.map(x => ({
+    return assets.map((x) => ({
       value: x.path,
       label: x.name,
       showCheckbox: false,
-      icon: x.type === 'folder' ? <i className="fa fa-folder" /> : <i className="fa fa-file" />,
-      children: x.contents ? contentsToNodes(x.contents) : null
+      icon:
+        x.type === 'folder' ? (
+          <FontAwesomeIcon icon={faFolder} />
+        ) : (
+          <FontAwesomeIcon icon={faFile} />
+        ),
+      children: x.contents ? contentsToNodes(x.contents) : null,
     }));
   }
 
@@ -23,7 +36,7 @@ class ProjectTemplatePreview extends Component {
     super(props);
     this.state = {
       checked: [],
-      expanded: ['Project Root']
+      expanded: ['Project Root'],
     };
   }
 
@@ -41,19 +54,33 @@ class ProjectTemplatePreview extends Component {
           value: 'Project Root',
           label: 'Project Root',
           showCheckbox: false,
-          children: templateContents
-        }
+          children: templateContents,
+        },
       ];
       preview = (
         <>
           <strong>Preview:</strong>
           <CheckboxTree
-            iconsClass="fa5"
+            icons={{
+              expandClose: (
+                <FontAwesomeIcon className="rct-icon rct-icon-expand-close" icon={faChevronRight} />
+              ),
+              expandOpen: (
+                <FontAwesomeIcon className="rct-icon rct-icon-expand-open" icon={faChevronDown} />
+              ),
+              parentClose: (
+                <FontAwesomeIcon className="rct-icon rct-icon-collapse-all" icon={faFolder} />
+              ),
+              parentOpen: (
+                <FontAwesomeIcon className="rct-icon rct-icon-parent-open" icon={faFolderOpen} />
+              ),
+              leaf: <FontAwesomeIcon className="rct-icon rct-icon-leaf-close" icon={faFile} />,
+            }}
             nodes={templateNodes}
             checked={this.state.checked}
             expanded={this.state.expanded}
-            onCheck={checked => this.setState({ checked })}
-            onExpand={expanded => this.setState({ expanded })}
+            onCheck={(checked) => this.setState({ checked })}
+            onExpand={(expanded) => this.setState({ expanded })}
           />
         </>
       );
@@ -68,11 +95,11 @@ class ProjectTemplatePreview extends Component {
 }
 
 ProjectTemplatePreview.propTypes = {
-  template: PropTypes.object
+  template: PropTypes.object,
 };
 
 ProjectTemplatePreview.defaultProps = {
-  template: null
+  template: null,
 };
 
 export default ProjectTemplatePreview;


### PR DESCRIPTION
# Summary of Changes

This pull request aims to resolve the Fontawesome Dependency Compatibility Issue in the Statwrap Project Preview. The update to Fontawesome version 6 caused the loss of icons in the project preview. This PR introduces updated custom icons compatible with Fontawesome version 6 and `react-checkbox-tree` to restore the missing icons in the project preview.

## Attachments

_Before (icons were not rendering properly)_ 

![image](https://github.com/StatTag/StatWrap/assets/64387054/9ad2fd67-e179-45dd-8ac6-54a9ec027f39)

_After (icons are rendering properly)_

![image](https://github.com/StatTag/StatWrap/assets/64387054/e6291af0-8159-4aea-9860-3881fbf7a8f6)

## Related Issue

Closes #188 

## Testing:

- Tested if icons are displaying properly or not 

   Used commands:
   
     - `yarn test` - all tests passed 
     - `yarn dev` - no UI fails detected
     - `yarn build` - no build fails detected
     - `yarn dev` - no new console errors detected
     
## Checklist

- [x] My code is well-documented, and I've updated relevant documentation.
- [x] I have tested these changes on my local environment.
- [x] I have reviewed and proofread my code and the changes.
- [x] The branch is up-to-date with the base branch.

## Additional Context

## Reviewer(s)

@lrasmus
