### PR TITLE
[FEATURE] : Introduces a component to display the entrypoints of the project.  🎉 

### DIFF
--- a/app/components/AssetDetails/AssetDetails.css
+++ b/app/components/AssetDetails/AssetDetails.css
@@ -1,4 +1,5 @@
 .container {
+  margin-bottom: 10px;
 }
 
 .title {

--- a/app/components/AssetDetails/AssetDetails.js
+++ b/app/components/AssetDetails/AssetDetails.js
@@ -18,18 +18,18 @@ const AccordionSummary = withStyles({
     marginBottom: -1,
     minHeight: 32,
     '&$expanded': {
-      minHeight: 32
-    }
+      minHeight: 32,
+    },
   },
   content: {
     '&$expanded': {
-      margin: '6px 0'
-    }
+      margin: '6px 0',
+    },
   },
-  expanded: {}
+  expanded: {},
 })(MuiAccordionSummary);
 
-const assetDetails = props => {
+const assetDetails = (props) => {
   const {
     asset,
     onAddedNote,
@@ -38,7 +38,7 @@ const assetDetails = props => {
     onUpdatedAttribute,
     assetAttributes,
     sourceControlEnabled,
-    dynamicDetails
+    dynamicDetails,
   } = props;
 
   const [expandNotes, setExpandNotes] = useState(false);
@@ -55,7 +55,7 @@ const assetDetails = props => {
   }, [asset]);
 
   const clickNotesAccordionHandler = () => {
-    setExpandNotes(prevState => !prevState);
+    setExpandNotes((prevState) => !prevState);
   };
 
   const updatedNoteHandler = (note, text) => {
@@ -68,7 +68,7 @@ const assetDetails = props => {
     }
   };
 
-  const deleteNoteHandler = note => {
+  const deleteNoteHandler = (note) => {
     if (onDeletedNote) {
       onDeletedNote(asset, note);
     }
@@ -125,7 +125,7 @@ const assetDetails = props => {
       <Accordion defaultExpanded>
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls="notes-attributes"
+          aria-controls="attributes-content"
           id="attributes-header"
           className={styles.heading}
         >

--- a/app/components/Project/Assets/Assets.css
+++ b/app/components/Project/Assets/Assets.css
@@ -2,10 +2,6 @@
   margin: 5px;
 }
 
-.filter {
-  width: 15%;
-}
-
 .tree {
   width: 50%;
   margin: 0;
@@ -20,6 +16,12 @@
   padding: 0;
   display: inline-block;
   vertical-align: top;
+}
+
+.entry {
+  width: 30%;
+  margin-left: 10px;
+  display: inline-block;
 }
 
 .toolbarButton {

--- a/app/components/Project/Assets/Assets.css
+++ b/app/components/Project/Assets/Assets.css
@@ -2,6 +2,15 @@
   margin: 5px;
 }
 
+.title {
+  margin-bottom: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.8em;
+  font-weight: bold;
+}
+
 .tree {
   width: 50%;
   margin: 0;

--- a/app/components/Project/Assets/Assets.css
+++ b/app/components/Project/Assets/Assets.css
@@ -18,12 +18,6 @@
   vertical-align: top;
 }
 
-.entry {
-  width: 30%;
-  margin-left: 10px;
-  display: inline-block;
-}
-
 .toolbarButton {
   font-size: 0.8rem !important;
 }

--- a/app/components/Project/Assets/Assets.js
+++ b/app/components/Project/Assets/Assets.js
@@ -406,13 +406,13 @@ const assetsComponent = (props) => {
             />
           </div>
           <div className={styles.details}>
-            {assetDetails}
             <div className={styles.title}>{project.path}</div>
             <ProjectEntryPoint
               assets={assets}
               rooturi={project.path}
               onSelect={handleEntryPointSelect}
             />
+            {assetDetails}
           </div>
           <AssetGroupDialog
             key={dialogKey}

--- a/app/components/Project/Assets/Assets.js
+++ b/app/components/Project/Assets/Assets.js
@@ -73,7 +73,7 @@ const assetsComponent = (props) => {
     onUpdatedAssetGroup,
     onDeletedAssetGroup,
     assetAttributes,
-    dynamicDetails
+    dynamicDetails,
   } = props;
   const [selectedAsset, setSelectedAsset] = useState();
   const treeRef = React.useRef(null);
@@ -127,11 +127,11 @@ const assetsComponent = (props) => {
     setCurrentAssetGroup(null);
     setGroupedAssets(null);
     setFilterEnabled(true);
-  }, [project.id]);
+  }, [project]);
 
   // Whenever the filter changes, update the list of assets to include only
   // those that should be displayed.
-  const handleFilterChanged = updatedFilter => {
+  const handleFilterChanged = (updatedFilter) => {
     setFilter(updatedFilter);
     setAssets(filterProjectAssets(project, updatedFilter));
   };
@@ -409,7 +409,7 @@ const assetsComponent = (props) => {
             <div className={styles.title}>{project.path}</div>
             <ProjectEntryPoint
               assets={assets}
-              rooturi={project.path}
+              rootUri={project.path}
               onSelect={handleEntryPointSelect}
             />
             {assetDetails}

--- a/app/components/Project/Assets/Assets.js
+++ b/app/components/Project/Assets/Assets.js
@@ -407,6 +407,7 @@ const assetsComponent = (props) => {
           </div>
           <div className={styles.details}>
             {assetDetails}
+            <div className={styles.title}>{project.path}</div>
             <ProjectEntryPoint
               assets={assets}
               rooturi={project.path}

--- a/app/components/Project/Assets/Assets.js
+++ b/app/components/Project/Assets/Assets.js
@@ -348,7 +348,7 @@ const assetsComponent = props => {
       // Note that for the AssetFilter component, we always want that to be the original
       // full list of assets.  That's why we use project.assets for that component's
       // propery, and the assets state variable for the AssetTree.
-      assetDisplay = project.assets.error ? (
+      assetDisplay = project.assets?.error ? (
         <Error>{assets.errorMessage}</Error>
       ) : (
         <>
@@ -406,11 +406,13 @@ const assetsComponent = props => {
             />
           </div>
           <div className={styles.details}>{assetDetails}</div>
-          <ProjectEntryPoint
-            assets={assets}
-            rooturi={project.path}
-            onSelect={handleEntryPointSelect}
-          />
+          <div className={styles.entry}>
+            <ProjectEntryPoint
+              assets={assets}
+              rooturi={project.path}
+              onSelect={handleEntryPointSelect}
+            />
+          </div>
           <AssetGroupDialog
             key={dialogKey}
             open={editingGroup}

--- a/app/components/Project/Assets/Assets.js
+++ b/app/components/Project/Assets/Assets.js
@@ -61,7 +61,7 @@ function resetFilter(project) {
   return project && project.assets ? ProjectUtil.getAssetFilters(project.assets) : [];
 }
 
-const assetsComponent = props => {
+const assetsComponent = (props) => {
   const {
     project,
     onAddedAssetNote,
@@ -152,7 +152,7 @@ const assetsComponent = props => {
     setEditingGroup(false);
   };
 
-  const handleSavedAssetGroup = group => {
+  const handleSavedAssetGroup = (group) => {
     if (group.id === null || group.id === undefined) {
       if (onAddedAssetGroup) {
         onAddedAssetGroup(group);
@@ -166,9 +166,9 @@ const assetsComponent = props => {
   // When the user selects a checkbox next to an asset - initially used just for building
   // asset groups, but consider if it could be more broadly repurposed.
   const handleCheckAsset = (asset, value) => {
-    setGroupedAssets(prevState => {
+    setGroupedAssets((prevState) => {
       const newAssetGroup = prevState ? [...prevState] : [];
-      const index = newAssetGroup.findIndex(x => x.uri === asset.uri);
+      const index = newAssetGroup.findIndex((x) => x.uri === asset.uri);
       // We only need to consider adding and removing - there are other branches of logic
       // that are essentialy noops.
       if (index === -1 && value) {
@@ -212,7 +212,7 @@ const assetsComponent = props => {
    * filtering available, but are keeping it simple for now.
    * @param {object} group The selected asset group (null if nothing is selected)
    */
-  const handleSelectAssetGroup = group => {
+  const handleSelectAssetGroup = (group) => {
     if (group === null) {
       setCurrentAssetGroup(null);
       setGroupedAssets(null);
@@ -227,7 +227,7 @@ const assetsComponent = props => {
       const groupAssets = {
         uri: clonedGroup.name,
         type: constants.AssetType.ASSET_GROUP,
-        children: clonedGroup.assets
+        children: clonedGroup.assets,
       };
 
       // Make sure we merge in the notes and attributes.  We don't store those for the
@@ -250,7 +250,7 @@ const assetsComponent = props => {
    *  4. The mode needs to be set to 'paperclip'
    * @param {object} group The group that is being edited
    */
-  const handleEditAssetGroup = group => {
+  const handleEditAssetGroup = (group) => {
     const clonedGroup = cloneDeep(group);
     setAssets(filterProjectAssets(project, filter));
     setCurrentAssetGroup(clonedGroup);
@@ -268,7 +268,7 @@ const assetsComponent = props => {
     handleSelectAssetGroup(currentAssetGroup);
   };
 
-  const handleDeleteAssetGroup = group => {
+  const handleDeleteAssetGroup = (group) => {
     // If we just deleted the selected asset group, clear the selection
     if (currentAssetGroup && currentAssetGroup.id === group.id) {
       setCurrentAssetGroup(null);
@@ -279,7 +279,7 @@ const assetsComponent = props => {
     }
   };
 
-  const handlSelectAsset = selAsset => {
+  const handlSelectAsset = (selAsset) => {
     let asset = selAsset;
     // When we are showing an asset group, the actual asset objects aren't the complete picture.
     // The extra logic we use here is to enrich the selected asset, if it's missing some key
@@ -405,8 +405,8 @@ const assetsComponent = props => {
               selectedAsset={selectedAsset}
             />
           </div>
-          <div className={styles.details}>{assetDetails}</div>
-          <div className={styles.entry}>
+          <div className={styles.details}>
+            {assetDetails}
             <ProjectEntryPoint
               assets={assets}
               rooturi={project.path}

--- a/app/components/Project/Assets/Assets.js
+++ b/app/components/Project/Assets/Assets.js
@@ -6,6 +6,7 @@ import AssetGroupDialog from '../../../containers/AssetGroupDialog/AssetGroupDia
 import Error from '../../Error/Error';
 import AssetTree from '../../AssetTree/AssetTree';
 import AssetDetails from '../../AssetDetails/AssetDetails';
+import ProjectEntryPoint from '../../ProjectEntryPoint/ProjectEntryPoint';
 import AssetFilter from '../../Filter/Filter';
 import EditableSelect from '../../EditableSelect/EditableSelect';
 import Loading from '../../Loading/Loading';
@@ -180,6 +181,29 @@ const assetsComponent = props => {
       }
       return newAssetGroup;
     });
+  };
+
+  const handleEntryPointSelect = (asset, expandedNodes) => {
+    let selAsset = asset;
+    if (selAsset && (selAsset.contentTypes === null || selAsset.contentTypes === undefined)) {
+      if (project && project.assets) {
+        selAsset = AssetUtil.findDescendantAssetByUri(project.assets, selAsset.uri);
+      }
+    }
+
+    setSelectedAsset(selAsset);
+    if (onSelectedAsset) {
+      onSelectedAsset(selAsset);
+    }
+
+    const expanded = treeRef.current.state.expandedNodes;
+    expandedNodes.map((a) => {
+      if (!expanded.includes(a)) {
+        expanded.push(a);
+      }
+      return null;
+    });
+    treeRef.current.setState({ expandedNodes: expanded });
   };
 
   /**
@@ -382,6 +406,11 @@ const assetsComponent = props => {
             />
           </div>
           <div className={styles.details}>{assetDetails}</div>
+          <ProjectEntryPoint
+            assets={assets}
+            rooturi={project.path}
+            onSelect={handleEntryPointSelect}
+          />
           <AssetGroupDialog
             key={dialogKey}
             open={editingGroup}

--- a/app/components/ProjectEntryPoint/ProjectEntryPoint.css
+++ b/app/components/ProjectEntryPoint/ProjectEntryPoint.css
@@ -1,34 +1,35 @@
-/* ProjectEntryPoint.css */
-
 .container {
-  padding: 15px;
-  margin: 10px;
+  padding: 20px;
+  margin-top: 10px;
   background-color: #eee;
   border: solid 1px gray;
   border-radius: 10px;
-  width: 40%;
+  width:max-content;
 }
 
 .entryPointList {
-  padding: 0;
+  padding-left: 10px;
 }
 
 .entryPointItem {
-  margin-bottom: 15px;
+  margin-bottom: 5px;
 }
 
 .entryPointItem button {
-  margin-left: 10px;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 5px;
+  background-color:whitesmoke;
+  border: solid 1px gainsboro;
+  transition: background-color 0.4s;
+}
+
+.entryPointItem button:hover {
+  background-color: gainsboro;
 }
 
 .entryPointUri {
   font-weight: bold;
   word-wrap: break-word;
   overflow-wrap: break-word;
-}
-
-.entryPointDetails {
-  margin-left: 20px;
-  font-size: 0.9rem;
-  color: #444;
 }

--- a/app/components/ProjectEntryPoint/ProjectEntryPoint.css
+++ b/app/components/ProjectEntryPoint/ProjectEntryPoint.css
@@ -1,14 +1,23 @@
 .container {
-  padding: 20px;
   margin-top: 10px;
-  background-color: #eee;
-  border: solid 1px gray;
-  border-radius: 10px;
-  width:max-content;
+}
+
+.heading {
+  background-color: #eee !important;
+  padding: 0 5px !important;
+}
+
+.headingTitle {
+  font-size: 1rem !important;
+  padding: 0 5px !important;
+}
+
+.details {
+  padding: 5px;
 }
 
 .entryPointList {
-  padding-left: 10px;
+  padding-left: 30px;
 }
 
 .entryPointItem {

--- a/app/components/ProjectEntryPoint/ProjectEntryPoint.css
+++ b/app/components/ProjectEntryPoint/ProjectEntryPoint.css
@@ -1,0 +1,34 @@
+/* ProjectEntryPoint.css */
+
+.container {
+  padding: 15px;
+  margin: 10px;
+  background-color: #eee;
+  border: solid 1px gray;
+  border-radius: 10px;
+  width: 40%;
+}
+
+.entryPointList {
+  padding: 0;
+}
+
+.entryPointItem {
+  margin-bottom: 15px;
+}
+
+.entryPointItem button {
+  margin-left: 10px;
+}
+
+.entryPointUri {
+  font-weight: bold;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.entryPointDetails {
+  margin-left: 20px;
+  font-size: 0.9rem;
+  color: #444;
+}

--- a/app/components/ProjectEntryPoint/ProjectEntryPoint.js
+++ b/app/components/ProjectEntryPoint/ProjectEntryPoint.js
@@ -4,6 +4,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFileImport, faShareFromSquare } from '@fortawesome/free-solid-svg-icons';
 import styles from './ProjectEntryPoint.css';
+import AssetUtil from '../../utils/asset';
 
 function findEntryPoints(asset, entryPointsList) {
   if (asset.attributes && asset.attributes.entrypoint === true) {
@@ -16,25 +17,14 @@ function findEntryPoints(asset, entryPointsList) {
   }
 }
 
-function findAllDescendantAssetsByUri(asseturi, uri) {
-  const descendantsList = [];
-  // just loop through the asset uri and break it apart at each '/' and add to the list till we get to the end
-  while (asseturi !== uri) {
-    const lastSlash = asseturi.lastIndexOf('/');
-    if (lastSlash === -1) {
-      break;
-    }
-    asseturi = asseturi.substring(0, lastSlash); // Update the variable instead of modifying the function parameter directly
-    descendantsList.push(asseturi);
-  }
-  return descendantsList;
-}
-
 const projectEntryPoint = (props) => {
-  const { assets, rooturi, onSelect } = props;
+  const { assets, rootUri, onSelect } = props;
 
   const setSelectedAsset = (asset) => {
-    const assetDescendantsUri = findAllDescendantAssetsByUri(asset.uri, rooturi).reverse();
+    const assetDescendantsUri = AssetUtil.findAllDescendantAssetsByUri(
+      asset.uri,
+      rootUri,
+    ).reverse();
     if (onSelect) {
       onSelect(asset, assetDescendantsUri);
     }
@@ -62,9 +52,9 @@ const projectEntryPoint = (props) => {
             <ul className={styles.entryPointList} type="disc">
               {entryPointsList.map((asset) => {
                 const fileName = asset.uri.split('/').pop();
-                let folder = asset.uri.replace(`${rooturi}/`, '').split('/')[0];
+                let folder = asset.uri.replace(`${rootUri}/`, '').split('/')[0];
                 if (folder === fileName) {
-                  folder = rooturi.split('/').pop();
+                  folder = rootUri.split('/').pop();
                 }
                 return (
                   <li key={asset.uri} className={styles.entryPointItem}>

--- a/app/components/ProjectEntryPoint/ProjectEntryPoint.js
+++ b/app/components/ProjectEntryPoint/ProjectEntryPoint.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, Typography } from '@mui/material';
+import { Accordion, AccordionDetails, AccordionSummary, Button, Typography } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFileImport, faShareFromSquare } from '@fortawesome/free-solid-svg-icons';
 import styles from './ProjectEntryPoint.css';
@@ -46,27 +47,39 @@ const projectEntryPoint = (props) => {
 
   if (entryPointsList && entryPointsList.length > 0) {
     return (
+      // eslint-disable-next-line react/jsx-filename-extension
       <div className={styles.container}>
-        <Typography variant="body1">Entry Points</Typography>
-        <ul className={styles.entryPointList} type='disc'>
-          {entryPointsList.map((asset) => {
-            const fileName = asset.uri.split('/').pop();
-            let folder = asset.uri.replace(rooturi + '/', '').split('/')[0];
-            if(folder === fileName) {
-              folder = rooturi.split('/').pop();
-            }
-            return (
-              <li key={asset.uri} className={styles.entryPointItem}>
-                <Typography className={styles.entryPointUri}>
-                  <FontAwesomeIcon icon={faFileImport} /> {fileName} ({folder})
-                </Typography>
-                <Button onClick={() => setSelectedAsset(asset)}>
-                  Navigate here &nbsp; <FontAwesomeIcon icon={faShareFromSquare} />
-                </Button>
-              </li>
-            );
-          })}
-        </ul>
+        <Accordion defaultExpanded>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="entry-points-content"
+            id="entry-points-header"
+            className={styles.heading}
+          >
+            <Typography className={styles.headingTitle}>Entry Points</Typography>
+          </AccordionSummary>
+          <AccordionDetails className={styles.details}>
+            <ul className={styles.entryPointList} type="disc">
+              {entryPointsList.map((asset) => {
+                const fileName = asset.uri.split('/').pop();
+                let folder = asset.uri.replace(`${rooturi}/`, '').split('/')[0];
+                if (folder === fileName) {
+                  folder = rooturi.split('/').pop();
+                }
+                return (
+                  <li key={asset.uri} className={styles.entryPointItem}>
+                    <Typography className={styles.entryPointUri}>
+                      <FontAwesomeIcon icon={faFileImport} /> {fileName} ({folder})
+                    </Typography>
+                    <Button onClick={() => setSelectedAsset(asset)}>
+                      Navigate here &nbsp; <FontAwesomeIcon icon={faShareFromSquare} />
+                    </Button>
+                  </li>
+                );
+              })}
+            </ul>
+          </AccordionDetails>
+        </Accordion>
       </div>
     );
   }

--- a/app/components/ProjectEntryPoint/ProjectEntryPoint.js
+++ b/app/components/ProjectEntryPoint/ProjectEntryPoint.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import styles from './ProjectEntryPoint.css';
+import { Button, Typography } from "@mui/material";
+
+
+function findEntryPoints(asset, entryPointsList) {
+  if (asset.attributes && asset.attributes.entrypoint === true) {
+    entryPointsList.push(asset);
+  }
+  if (asset.children) {
+    asset.children.forEach((child) => {
+      findEntryPoints(child, entryPointsList);
+    });
+  }
+}
+
+function findAllDescendantAssetsByUri(asseturi, uri) {
+  const descendantsList = [];
+  descendantsList.push(asseturi); // Add the asset uri to the list
+  let updatedAssetUri = asseturi; // Create a new variable to store the updated value
+  // just loop through the asset uri and break it apart at each '/' and add to the list till we get to the end
+  while (updatedAssetUri !== uri) {
+    const lastSlash = updatedAssetUri.lastIndexOf('/');
+    if (lastSlash === -1) {
+      break;
+    }
+    updatedAssetUri = updatedAssetUri.substring(0, lastSlash); // Update the new variable instead of modifying the function parameter directly
+    descendantsList.push(updatedAssetUri);
+  }
+  return descendantsList;
+}
+
+const projectEntryPoint = (props) => {
+  const { assets, rooturi, onSelect } = props;
+
+  const setSelectedAsset = (asset) => {
+    const assetDescendantsUri = findAllDescendantAssetsByUri(asset.uri, rooturi).reverse();
+    if (onSelect) {
+      onSelect(asset, assetDescendantsUri);
+    }
+  };
+  const entryPointsList = [];
+  if (assets) {
+    findEntryPoints(assets, entryPointsList);
+  }
+
+  if (entryPointsList && entryPointsList.length > 0) {
+    return (
+      <div className={styles.container}>
+        <Typography variant="h6">Entry Points</Typography>
+        <ol className={styles.entryPointList} type='1'>
+          {entryPointsList.map((asset) => {
+            return (
+              <li key={asset.id} className={styles.entryPointItem}>
+                <div>
+                  <Typography className={styles.entryPointUri}>{asset.uri}</Typography>
+                  <Button onClick={() => setSelectedAsset(asset)}>Navigate here.</Button>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default projectEntryPoint;

--- a/app/components/ProjectEntryPoint/ProjectEntryPoint.js
+++ b/app/components/ProjectEntryPoint/ProjectEntryPoint.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Button, Typography } from '@mui/material';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFileImport, faShareFromSquare } from '@fortawesome/free-solid-svg-icons';
 import styles from './ProjectEntryPoint.css';
-import { Button, Typography } from "@mui/material";
-
 
 function findEntryPoints(asset, entryPointsList) {
   if (asset.attributes && asset.attributes.entrypoint === true) {
@@ -16,16 +17,14 @@ function findEntryPoints(asset, entryPointsList) {
 
 function findAllDescendantAssetsByUri(asseturi, uri) {
   const descendantsList = [];
-  descendantsList.push(asseturi); // Add the asset uri to the list
-  let updatedAssetUri = asseturi; // Create a new variable to store the updated value
   // just loop through the asset uri and break it apart at each '/' and add to the list till we get to the end
-  while (updatedAssetUri !== uri) {
-    const lastSlash = updatedAssetUri.lastIndexOf('/');
+  while (asseturi !== uri) {
+    const lastSlash = asseturi.lastIndexOf('/');
     if (lastSlash === -1) {
       break;
     }
-    updatedAssetUri = updatedAssetUri.substring(0, lastSlash); // Update the new variable instead of modifying the function parameter directly
-    descendantsList.push(updatedAssetUri);
+    asseturi = asseturi.substring(0, lastSlash); // Update the variable instead of modifying the function parameter directly
+    descendantsList.push(asseturi);
   }
   return descendantsList;
 }
@@ -39,6 +38,7 @@ const projectEntryPoint = (props) => {
       onSelect(asset, assetDescendantsUri);
     }
   };
+
   const entryPointsList = [];
   if (assets) {
     findEntryPoints(assets, entryPointsList);
@@ -47,19 +47,26 @@ const projectEntryPoint = (props) => {
   if (entryPointsList && entryPointsList.length > 0) {
     return (
       <div className={styles.container}>
-        <Typography variant="h6">Entry Points</Typography>
-        <ol className={styles.entryPointList} type='1'>
+        <Typography variant="body1">Entry Points</Typography>
+        <ul className={styles.entryPointList} type='disc'>
           {entryPointsList.map((asset) => {
+            const fileName = asset.uri.split('/').pop();
+            let folder = asset.uri.replace(rooturi + '/', '').split('/')[0];
+            if(folder === fileName) {
+              folder = rooturi.split('/').pop();
+            }
             return (
-              <li key={asset.id} className={styles.entryPointItem}>
-                <div>
-                  <Typography className={styles.entryPointUri}>{asset.uri}</Typography>
-                  <Button onClick={() => setSelectedAsset(asset)}>Navigate here.</Button>
-                </div>
+              <li key={asset.uri} className={styles.entryPointItem}>
+                <Typography className={styles.entryPointUri}>
+                  <FontAwesomeIcon icon={faFileImport} /> {fileName} ({folder})
+                </Typography>
+                <Button onClick={() => setSelectedAsset(asset)}>
+                  Navigate here &nbsp; <FontAwesomeIcon icon={faShareFromSquare} />
+                </Button>
               </li>
             );
           })}
-        </ol>
+        </ul>
       </div>
     );
   }

--- a/app/services/assets/asset.js
+++ b/app/services/assets/asset.js
@@ -23,11 +23,11 @@ export default class AssetService {
 
     this.assetContentTypesByExtension = GeneralUtil.indexByField(
       contentTypes || AssetsConfig.contentTypes,
-      'extensions'
+      'extensions',
     );
     this.assetContentTypesByCategory = GeneralUtil.indexByField(
       contentTypes || AssetsConfig.contentTypes,
-      'categories'
+      'categories',
     );
   }
 
@@ -102,7 +102,7 @@ export default class AssetService {
       uri,
       type: this.assetType(details),
       contentTypes: this.assetContentTypes(uri, details),
-      metadata: []
+      metadata: [],
     };
 
     // If this is a directory, we are going to traverse and get details

--- a/app/utils/asset.js
+++ b/app/utils/asset.js
@@ -118,18 +118,23 @@ export default class AssetUtil {
 
   static findAllDescendantAssetsByUri(assetUri, rootUri) {
     const descendantsList = [];
-    // just loop through the asset uri and break it apart at each '/' and add to the list till we get to the root uri
-    while (assetUri !== rootUri) {
-      const lastSlash = assetUri.lastIndexOf('/');
-      // If we can't find a slash, we can't go any further
-      if (lastSlash === -1) {
-        break;
+    // check if the asset uri has a descendant root uri in it
+    if (assetUri && rootUri && assetUri.includes(rootUri) && assetUri.indexOf(rootUri) === 0) {
+      // just loop through the asset uri and break it apart at each '/' and add to the list till we get to the root uri
+      while (assetUri !== rootUri && assetUri !== '') {
+        const lastSlash = assetUri.lastIndexOf('/');
+        // If we can't find a slash, we can't go any further
+        if (lastSlash === -1) {
+          break;
+        }
+        // Update the variable instead of modifying the function parameter directly
+        // eslint-disable-next-line no-param-reassign
+        assetUri = assetUri.substring(0, lastSlash);
+        // Add the asset uri to the list
+        if (assetUri) {
+          descendantsList.push(assetUri);
+        }
       }
-      // Update the variable instead of modifying the function parameter directly
-      // eslint-disable-next-line no-param-reassign
-      assetUri = assetUri.substring(0, lastSlash);
-      // Add the asset uri to the list
-      descendantsList.push(assetUri);
     }
 
     return descendantsList;

--- a/app/utils/asset.js
+++ b/app/utils/asset.js
@@ -17,7 +17,7 @@ export default class AssetUtil {
       return null;
     }
 
-    const entry = metadata.find(m => {
+    const entry = metadata.find((m) => {
       return m && m.id === handler;
     });
     return entry || null;
@@ -52,10 +52,10 @@ export default class AssetUtil {
     const filteredAsset = { ...asset, children: [...asset.children] };
     for (let index = 0; index < filteredAsset.children.length; index++) {
       filteredAsset.children[index] = AssetUtil.filterIncludedFileAssets(
-        filteredAsset.children[index]
+        filteredAsset.children[index],
       );
     }
-    filteredAsset.children = filteredAsset.children.filter(c => c);
+    filteredAsset.children = filteredAsset.children.filter((c) => c);
     return filteredAsset;
   }
 
@@ -70,7 +70,7 @@ export default class AssetUtil {
       return null;
     }
 
-    const child = asset.children.find(a => {
+    const child = asset.children.find((a) => {
       return a && a.uri === uri;
     });
 
@@ -110,13 +110,39 @@ export default class AssetUtil {
   }
 
   /**
+   * Find all the descendant assets for the asset parameter, based on the specified URI.  This involves
+   * looping through the asset uri to find all the descendant folder path and returning them in an array.
+   * @param {string} assetUri The asset URI to search for descendants
+   * @param {string} rootUri The root URI to stop searching for descendants
+   */
+
+  static findAllDescendantAssetsByUri(assetUri, rootUri) {
+    const descendantsList = [];
+    // just loop through the asset uri and break it apart at each '/' and add to the list till we get to the root uri
+    while (assetUri !== rootUri) {
+      const lastSlash = assetUri.lastIndexOf('/');
+      // If we can't find a slash, we can't go any further
+      if (lastSlash === -1) {
+        break;
+      }
+      // Update the variable instead of modifying the function parameter directly
+      // eslint-disable-next-line no-param-reassign
+      assetUri = assetUri.substring(0, lastSlash);
+      // Add the asset uri to the list
+      descendantsList.push(assetUri);
+    }
+
+    return descendantsList;
+  }
+
+  /**
    * Recursively collect and flatten all asset notes into an array
    * @param {object} asset The asset to find all notes for
    */
   static getAllNotes(asset) {
     const notes =
       asset && asset.notes
-        ? asset.notes.map(n => {
+        ? asset.notes.map((n) => {
             return { ...n, uri: asset.uri };
           })
         : [];
@@ -210,7 +236,7 @@ export default class AssetUtil {
         asset.children[index] = AssetUtil._recursivePathConversion(
           projectPath,
           asset.children[index],
-          workerFn
+          workerFn,
         );
       }
     }

--- a/app/utils/workflow.js
+++ b/app/utils/workflow.js
@@ -63,12 +63,12 @@ export default class WorkflowUtil {
    */
   static getAllDependenciesAsEChartGraph(asset, filters) {
     const graph = WorkflowUtil.getAllDependenciesAsGraph(asset, filters);
-    graph.nodes = graph.nodes.map(x => ({
+    graph.nodes = graph.nodes.map((x) => ({
       id: x.id,
       name: WorkflowUtil.getShortDependencyName(x.id),
       fullName: x.id,
       direction: x.direction,
-      value: x.assetType
+      value: x.assetType,
     }));
     return graph;
   }
@@ -83,7 +83,7 @@ export default class WorkflowUtil {
   static getAllDependenciesAsGraph(asset, filters) {
     const graph = {
       nodes: [],
-      links: []
+      links: [],
     };
 
     if (!asset || !asset.uri) {
@@ -92,15 +92,15 @@ export default class WorkflowUtil {
 
     const applyFilter = filters !== null && filters !== undefined && filters.length > 0;
     const typeFilterIndex = applyFilter
-      ? filters.findIndex(x => x.category === Constants.FilterCategory.FILE_TYPE)
+      ? filters.findIndex((x) => x.category === Constants.FilterCategory.FILE_TYPE)
       : -1;
     const typeFilter = typeFilterIndex === -1 ? null : filters[typeFilterIndex];
     const ioFilterIndex = applyFilter
-      ? filters.findIndex(x => x.category === Constants.FilterCategory.INPUTS_OUTPUTS)
+      ? filters.findIndex((x) => x.category === Constants.FilterCategory.INPUTS_OUTPUTS)
       : -1;
     const ioFilter = ioFilterIndex === -1 ? null : filters[ioFilterIndex];
     const dependencyFilterIndex = applyFilter
-      ? filters.findIndex(x => x.category === Constants.FilterCategory.DEPENDENCIES)
+      ? filters.findIndex((x) => x.category === Constants.FilterCategory.DEPENDENCIES)
       : -1;
     const dependencyFilter = dependencyFilterIndex === -1 ? null : filters[dependencyFilterIndex];
     const allDeps = WorkflowUtil.getAllDependencies(asset, asset.uri);
@@ -109,7 +109,7 @@ export default class WorkflowUtil {
       if (entry.asset && entry.dependencies && entry.dependencies.length > 0) {
         // If we have a file type filter to apply, and we are supposed to filter this
         // asset out, skip further processing.
-        if (typeFilter && typeFilter.values.some(x => !x.value && x.key === entry.assetType)) {
+        if (typeFilter && typeFilter.values.some((x) => !x.value && x.key === entry.assetType)) {
           continue;
         }
 
@@ -123,14 +123,14 @@ export default class WorkflowUtil {
           if (
             ioFilter &&
             ioFilter.values.some(
-              x =>
+              (x) =>
                 // Only consider filters that are turned off
                 !x.value &&
                 // If the filter is for dependencies, it is a match if there is
                 // no dependency.type value (we leave that empty).  If there is
                 // a dependency.type and it matches the key, filter it out.
                 (x.key === dependency.type ||
-                  (x.key === Constants.DependencyType.DEPENDENCY && !dependency.type))
+                  (x.key === Constants.DependencyType.DEPENDENCY && !dependency.type)),
             )
           ) {
             continue;
@@ -141,7 +141,7 @@ export default class WorkflowUtil {
           if (
             dependencyFilter &&
             dependencyFilter.values.some(
-              x => !x.value && !dependency.type && x.key === dependency.id
+              (x) => !x.value && !dependency.type && x.key === dependency.id,
             )
           ) {
             continue;
@@ -150,11 +150,11 @@ export default class WorkflowUtil {
           const dependencyId = dependency.id;
           // We need to see if we already have an dependency before we add it as a node (to avoid
           // duplicate nodes with the same ID).
-          if (!graph.nodes.some(n => n.id === dependencyId)) {
+          if (!graph.nodes.some((n) => n.id === dependencyId)) {
             graph.nodes.push({
               id: dependencyId,
               assetType: dependency.type ? dependency.type : Constants.DependencyType.DEPENDENCY,
-              direction: dependency.direction
+              direction: dependency.direction,
             });
           }
           // Likewise, we have to make sure that any edge is unique before we add it
@@ -162,7 +162,7 @@ export default class WorkflowUtil {
             dependency.direction === Constants.DependencyDirection.IN ? dependencyId : entry.asset;
           const target =
             dependency.direction === Constants.DependencyDirection.IN ? entry.asset : dependencyId;
-          if (!graph.links.some(l => l.source === source && l.target === target)) {
+          if (!graph.links.some((l) => l.source === source && l.target === target)) {
             graph.links.push({ source, target });
           }
         }
@@ -186,8 +186,8 @@ export default class WorkflowUtil {
       name: AssetUtil.getAssetNameFromUri(asset),
       children: null,
       attributes: {
-        assetType: WorkflowUtil.getAssetType(asset)
-      }
+        assetType: WorkflowUtil.getAssetType(asset),
+      },
     };
 
     if (asset.children) {
@@ -206,7 +206,7 @@ export default class WorkflowUtil {
       const entry = allDeps[index];
       const depEntry = {
         name: entry.id,
-        attributes: { assetType: Constants.AssetType.DEPENDENCY }
+        attributes: { assetType: Constants.AssetType.DEPENDENCY },
       };
       // Only push dependencies once (to avoid unnecessary clutter)
       // eslint-disable-next-line prettier/prettier
@@ -263,16 +263,16 @@ export default class WorkflowUtil {
     WorkflowUtil._getMetadataDependencies(asset, StataHandler.id, libraries, inputs, outputs);
 
     return libraries
-      .map(e => {
+      .map((e) => {
         return { ...e, direction: Constants.DependencyDirection.IN };
       })
       .concat(
-        inputs.map(e => {
+        inputs.map((e) => {
           return { ...e, direction: Constants.DependencyDirection.IN };
         }),
-        outputs.map(e => {
+        outputs.map((e) => {
           return { ...e, direction: Constants.DependencyDirection.OUT };
-        })
+        }),
       );
   }
 
@@ -295,8 +295,8 @@ export default class WorkflowUtil {
           {
             asset: rootUri ? asset.uri.replace(rootUri, '').replace(/^\\+|\/+/, '') : asset.uri,
             assetType: WorkflowUtil.getAssetType(asset),
-            dependencies: WorkflowUtil.getDependencies(asset)
-          }
+            dependencies: WorkflowUtil.getDependencies(asset),
+          },
         ]
       : [];
     if (!asset || !asset.children) {

--- a/test/utils/asset.spec.js
+++ b/test/utils/asset.spec.js
@@ -20,13 +20,13 @@ describe('services', () => {
         const metadata = [
           {
             id: 'Test.Id',
-            value: true
+            value: true,
           },
           null,
           {
             id: 'Other.Id',
-            value: false
-          }
+            value: false,
+          },
         ];
         expect(AssetUtil.getHandlerMetadata('Test.Id', metadata)).not.toBeNull();
         expect(AssetUtil.getHandlerMetadata('INVALID', metadata)).toBeNull();
@@ -69,9 +69,9 @@ describe('services', () => {
           metadata: [
             {
               id: 'StatWrap.FileHandler',
-              include: false
-            }
-          ]
+              include: false,
+            },
+          ],
         };
         expect(AssetUtil.filterIncludedFileAssets(asset)).toBeNull();
       });
@@ -82,9 +82,9 @@ describe('services', () => {
           metadata: [
             {
               id: 'StatWrap.FileHandler',
-              include: true
-            }
-          ]
+              include: true,
+            },
+          ],
         };
         expect(AssetUtil.filterIncludedFileAssets(asset)).not.toBeNull();
 
@@ -104,8 +104,8 @@ describe('services', () => {
           metadata: [
             {
               id: 'StatWrap.FileHandler',
-              include: true
-            }
+              include: true,
+            },
           ],
           children: [
             {
@@ -113,20 +113,20 @@ describe('services', () => {
               metadata: [
                 {
                   id: 'StatWrap.FileHandler',
-                  include: false
-                }
-              ]
+                  include: false,
+                },
+              ],
             },
             {
               uri: '/Test/Asset/Child2',
               metadata: [
                 {
                   id: 'StatWrap.FileHandler',
-                  include: false
-                }
-              ]
-            }
-          ]
+                  include: false,
+                },
+              ],
+            },
+          ],
         };
         expect(AssetUtil.filterIncludedFileAssets(asset).children.length).toEqual(0);
       });
@@ -137,8 +137,8 @@ describe('services', () => {
           metadata: [
             {
               id: 'StatWrap.FileHandler',
-              include: true
-            }
+              include: true,
+            },
           ],
           children: [
             {
@@ -146,29 +146,29 @@ describe('services', () => {
               metadata: [
                 {
                   id: 'StatWrap.FileHandler',
-                  include: true
-                }
-              ]
+                  include: true,
+                },
+              ],
             },
             {
               uri: '/Test/Asset/Child2',
               metadata: [
                 {
                   id: 'StatWrap.FileHandler',
-                  include: false
-                }
-              ]
+                  include: false,
+                },
+              ],
             },
             {
               uri: '/Test/Asset/Child3',
               metadata: [
                 {
                   id: 'StatWrap.FileHandler',
-                  include: true
-                }
-              ]
-            }
-          ]
+                  include: true,
+                },
+              ],
+            },
+          ],
         };
         const filteredAsset = AssetUtil.filterIncludedFileAssets(asset);
         expect(filteredAsset.children.length).toEqual(2);
@@ -182,8 +182,8 @@ describe('services', () => {
           metadata: [
             {
               id: 'StatWrap.FileHandler',
-              include: true
-            }
+              include: true,
+            },
           ],
           children: [
             {
@@ -191,17 +191,17 @@ describe('services', () => {
               metadata: [
                 {
                   id: 'StatWrap.FileHandler',
-                  include: false
-                }
-              ]
+                  include: false,
+                },
+              ],
             },
             {
               uri: '/Test/Asset/Child2',
               metadata: [
                 {
                   id: 'StatWrap.FileHandler',
-                  include: false
-                }
+                  include: false,
+                },
               ],
               children: [
                 {
@@ -209,19 +209,19 @@ describe('services', () => {
                   metadata: [
                     {
                       id: 'StatWrap.FileHandler',
-                      include: true // Even though this is include, the parent is hidden
-                    }
-                  ]
-                }
-              ]
+                      include: true, // Even though this is include, the parent is hidden
+                    },
+                  ],
+                },
+              ],
             },
             {
               uri: '/Test/Asset/Child3',
               metadata: [
                 {
                   id: 'StatWrap.FileHandler',
-                  include: true
-                }
+                  include: true,
+                },
               ],
               children: [
                 {
@@ -229,22 +229,22 @@ describe('services', () => {
                   metadata: [
                     {
                       id: 'StatWrap.FileHandler',
-                      include: false
-                    }
-                  ]
+                      include: false,
+                    },
+                  ],
                 },
                 {
                   uri: '/Test/Asset/Child3/Child2',
                   metadata: [
                     {
                       id: 'StatWrap.FileHandler',
-                      include: true
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+                      include: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
         };
         const filteredAsset = AssetUtil.filterIncludedFileAssets(asset);
         expect(filteredAsset.children.length).toEqual(1);
@@ -253,7 +253,7 @@ describe('services', () => {
         // This is what's testing that we didn't modify the original object.  If
         // we had modified it, this access of the descendant would fail.
         expect(filteredAsset.children[0].children[0].uri).toEqual(
-          asset.children[2].children[1].uri
+          asset.children[2].children[1].uri,
         );
       });
     });
@@ -278,7 +278,7 @@ describe('services', () => {
       it('should should return null if there is no matching child', () => {
         expect(AssetUtil.findChildAssetByUri({ children: [] }, '/Test')).toBeNull();
         expect(
-          AssetUtil.findChildAssetByUri({ children: [{ uri: '/Test2' }] }, '/Test')
+          AssetUtil.findChildAssetByUri({ children: [{ uri: '/Test2' }] }, '/Test'),
         ).toBeNull();
         // We expect case to match exactly for URI
         expect(AssetUtil.findChildAssetByUri({ children: [{ uri: '/TeST' }] }, '/Test')).toBeNull();
@@ -289,8 +289,8 @@ describe('services', () => {
           children: [
             { uri: '/Test1', test: 1 },
             { uri: '/Test2', test: 2 },
-            { uri: '/Test3', test: 3 }
-          ]
+            { uri: '/Test3', test: 3 },
+          ],
         };
         expect(AssetUtil.findChildAssetByUri(asset, '/Test1').test).toBe(1);
         expect(AssetUtil.findChildAssetByUri(asset, '/Test2').test).toBe(2);
@@ -322,11 +322,11 @@ describe('services', () => {
       it('should should return null if there is no matching descendant', () => {
         expect(AssetUtil.findDescendantAssetByUri({ children: [] }, '/Test')).toBeNull();
         expect(
-          AssetUtil.findDescendantAssetByUri({ children: [{ uri: '/Test2' }] }, '/Test')
+          AssetUtil.findDescendantAssetByUri({ children: [{ uri: '/Test2' }] }, '/Test'),
         ).toBeNull();
         // We expect case to match exactly for URI
         expect(
-          AssetUtil.findDescendantAssetByUri({ children: [{ uri: '/TeST' }] }, '/Test')
+          AssetUtil.findDescendantAssetByUri({ children: [{ uri: '/TeST' }] }, '/Test'),
         ).toBeNull();
       });
 
@@ -338,8 +338,8 @@ describe('services', () => {
               test: 1,
               children: [
                 { uri: '/Test1/a', test: 4 },
-                { uri: '/Test1/b', test: 5 }
-              ]
+                { uri: '/Test1/b', test: 5 },
+              ],
             },
             { uri: '/Test2', test: 2 },
             {
@@ -347,10 +347,10 @@ describe('services', () => {
               test: 3,
               children: [
                 { uri: '/Test3/a', test: 6 },
-                { uri: '/Test3/b', test: 7 }
-              ]
-            }
-          ]
+                { uri: '/Test3/b', test: 7 },
+              ],
+            },
+          ],
         };
         expect(AssetUtil.findDescendantAssetByUri(asset, '/Test1').test).toBe(1);
         expect(AssetUtil.findDescendantAssetByUri(asset, '/Test2').test).toBe(2);
@@ -362,6 +362,37 @@ describe('services', () => {
       });
     });
 
+    describe('findAllDescendantAssetsByUri', () => {
+      it('should return an empty array if the asset URI is not specified', () => {
+        expect(AssetUtil.findAllDescendantAssetsByUri(null, '/Test')).toBeArrayOfSize(0);
+        expect(AssetUtil.findAllDescendantAssetsByUri(undefined, '/Test')).toBeArrayOfSize(0);
+      });
+      it('should return an empty array if the root URI is not specified', () => {
+        expect(AssetUtil.findAllDescendantAssetsByUri('/Test', null)).toBeArrayOfSize(0);
+        expect(AssetUtil.findAllDescendantAssetsByUri('/Test', undefined)).toBeArrayOfSize(0);
+      });
+      it('should return an empty array if the asset URI and root URI are the same', () => {
+        expect(
+          AssetUtil.findAllDescendantAssetsByUri('/Test/Child', '/Test/Child'),
+        ).toBeArrayOfSize(0);
+      });
+      it('should return an empty array if the asset URI is not a descendant of the root URI', () => {
+        expect(AssetUtil.findAllDescendantAssetsByUri('/Test', '/Other')).toBeArrayOfSize(0);
+      });
+      it('should return an array containing all descendant URIs up to the root URI', () => {
+        expect(AssetUtil.findAllDescendantAssetsByUri('/Test/Child1/Child2', '/Test')).toEqual([
+          '/Test/Child1',
+          '/Test',
+        ]);
+      });
+      it('should return an empty array if the asset URI is a filename', () => {
+        expect(AssetUtil.findAllDescendantAssetsByUri('/Test', '/')).toBeArrayOfSize(0);
+      });
+      it('should return an empty array if the asset URI contains root URI but not as a prefix', () => {
+        expect(AssetUtil.findAllDescendantAssetsByUri('/Test/Rt/Child', '/Rt')).toBeArrayOfSize(0);
+      });
+    });
+
     describe('getAllNotes', () => {
       it('should return an empty array if the asset is not specified', () => {
         expect(AssetUtil.getAllNotes(null)).toBeArrayOfSize(0);
@@ -370,7 +401,7 @@ describe('services', () => {
 
       it('should should return an empty array when there are no notes', () => {
         const asset = {
-          children: []
+          children: [],
         };
         expect(AssetUtil.getAllNotes(asset)).toBeArrayOfSize(0);
       });
@@ -384,9 +415,9 @@ describe('services', () => {
               author: 'test',
               updated: '2021-01-01',
               content: 'Test note',
-              uri: '/testt/1'
-            }
-          ]
+              uri: '/testt/1',
+            },
+          ],
         };
         expect(AssetUtil.getAllNotes(asset)).toBeArrayOfSize(1);
       });
@@ -399,8 +430,8 @@ describe('services', () => {
               id: '1',
               author: 'test',
               updated: '2021-01-01',
-              content: 'Test note 1'
-            }
+              content: 'Test note 1',
+            },
           ],
           children: [
             {
@@ -410,8 +441,8 @@ describe('services', () => {
                   id: '2',
                   author: 'test',
                   updated: '2021-01-01',
-                  content: 'Test note 2'
-                }
+                  content: 'Test note 2',
+                },
               ],
               children: [
                 {
@@ -421,11 +452,11 @@ describe('services', () => {
                       id: '3',
                       author: 'test',
                       updated: '2021-01-01',
-                      content: 'Test note 3'
-                    }
-                  ]
-                }
-              ]
+                      content: 'Test note 3',
+                    },
+                  ],
+                },
+              ],
             },
             {
               uri: '/test/1/2',
@@ -434,18 +465,18 @@ describe('services', () => {
                   id: '4',
                   author: 'test',
                   updated: '2021-01-01',
-                  content: 'Test note 4'
+                  content: 'Test note 4',
                 },
                 {
                   id: '5',
                   author: 'test',
                   updated: '2021-01-01',
-                  content: 'Test note 5'
-                }
+                  content: 'Test note 5',
+                },
               ],
-              children: []
-            }
-          ]
+              children: [],
+            },
+          ],
         };
         expect(AssetUtil.getAllNotes(asset)).toBeArrayOfSize(5);
       });
@@ -471,20 +502,20 @@ describe('services', () => {
         'should return the name and extension for an object containing a uri attribute',
         () => {
           expect(AssetUtil.getAssetNameFromUri({ uri: 'C:\\Test\\Path\\file.test' })).toEqual(
-            'file.test'
+            'file.test',
           );
           expect(AssetUtil.getAssetNameFromUri({ uri: 'file.test' })).toEqual('file.test');
-        }
+        },
       );
 
       it.onMac(
         'should return the name and extension for an object containing a uri attribute',
         () => {
           expect(AssetUtil.getAssetNameFromUri({ uri: '/Test/Path/file.test' })).toEqual(
-            'file.test'
+            'file.test',
           );
           expect(AssetUtil.getAssetNameFromUri({ uri: 'file.test' })).toEqual('file.test');
-        }
+        },
       );
 
       it('should return an empty string for an object without a uri attribute', () => {
@@ -510,11 +541,11 @@ describe('services', () => {
       });
       it.onWindows('should return the root path if the uri is empty', () => {
         expect(AssetUtil.relativeToAbsolutePath('C:\\root\\path', { uri: '' })).toBe(
-          'C:\\root\\path'
+          'C:\\root\\path',
         );
         // Trailing spaces are preserved on macOS
         expect(AssetUtil.relativeToAbsolutePath('C:\\root\\path', { uri: '  ' })).toBe(
-          'C:\\root\\path\\  '
+          'C:\\root\\path\\  ',
         );
       });
 
@@ -524,7 +555,7 @@ describe('services', () => {
         expect(AssetUtil.relativeToAbsolutePath('/root/path', { uri: 'a' })).toBe('/root/path/a');
         expect(AssetUtil.relativeToAbsolutePath('/root/path', { uri: './a' })).toBe('/root/path/a');
         expect(AssetUtil.relativeToAbsolutePath('/root/path', { uri: 'a/b/c/d' })).toBe(
-          '/root/path/a/b/c/d'
+          '/root/path/a/b/c/d',
         );
         // TODO: Need an assessment if this is a security risk and if we should restrict how we navigate
         // beyond the project root
@@ -533,21 +564,21 @@ describe('services', () => {
       });
       it.onWindows('should resolve the absolute path', () => {
         expect(AssetUtil.relativeToAbsolutePath('C:\\root\\path', { uri: 'a' })).toBe(
-          'C:\\root\\path\\a'
+          'C:\\root\\path\\a',
         );
         expect(AssetUtil.relativeToAbsolutePath('C:\\root\\path', { uri: './a' })).toBe(
-          'C:\\root\\path\\a'
+          'C:\\root\\path\\a',
         );
         expect(AssetUtil.relativeToAbsolutePath('C:\\root\\path', { uri: 'a/b/c/d' })).toBe(
-          'C:\\root\\path\\a\\b\\c\\d'
+          'C:\\root\\path\\a\\b\\c\\d',
         );
         // TODO: Need an assessment if this is a security risk and if we should restrict how we navigate
         // beyond the project root
         expect(AssetUtil.relativeToAbsolutePath('C:\\root\\path', { uri: '..\\a' })).toBe(
-          'C:\\root\\a'
+          'C:\\root\\a',
         );
         expect(AssetUtil.relativeToAbsolutePath('C:\\root\\path', { uri: 'a\\..' })).toBe(
-          'C:\\root\\path'
+          'C:\\root\\path',
         );
       });
     });
@@ -560,7 +591,7 @@ describe('services', () => {
 
       it('should return the asset object if the project path is not provided', () => {
         const assets = {
-          uri: '/tmp/root'
+          uri: '/tmp/root',
         };
         expect(AssetUtil.recursiveRelativeToAbsolutePath(null, assets)).toBe(assets);
         expect(AssetUtil.recursiveRelativeToAbsolutePath(undefined, assets)).toBe(assets);
@@ -577,15 +608,15 @@ describe('services', () => {
               children: [
                 {
                   uri: 'a/b',
-                  type: 'file'
-                }
-              ]
+                  type: 'file',
+                },
+              ],
             },
             {
               uri: 'b',
-              type: 'file'
-            }
-          ]
+              type: 'file',
+            },
+          ],
         };
         // This is the answer we expect
         const absolutePathAssets = {
@@ -598,18 +629,18 @@ describe('services', () => {
               children: [
                 {
                   uri: '/root/path/a/b',
-                  type: 'file'
-                }
-              ]
+                  type: 'file',
+                },
+              ],
             },
             {
               uri: '/root/path/b',
-              type: 'file'
-            }
-          ]
+              type: 'file',
+            },
+          ],
         };
         expect(AssetUtil.recursiveRelativeToAbsolutePath('/root/path', assets)).toStrictEqual(
-          absolutePathAssets
+          absolutePathAssets,
         );
       });
 
@@ -624,15 +655,15 @@ describe('services', () => {
               children: [
                 {
                   uri: 'a/b',
-                  type: 'file'
-                }
-              ]
+                  type: 'file',
+                },
+              ],
             },
             {
               uri: 'b',
-              type: 'file'
-            }
-          ]
+              type: 'file',
+            },
+          ],
         };
         // This is the answer we expect
         const absolutePathAssets = {
@@ -645,18 +676,18 @@ describe('services', () => {
               children: [
                 {
                   uri: 'C:\\root\\path\\a\\b',
-                  type: 'file'
-                }
-              ]
+                  type: 'file',
+                },
+              ],
             },
             {
               uri: 'C:\\root\\path\\b',
-              type: 'file'
-            }
-          ]
+              type: 'file',
+            },
+          ],
         };
         expect(AssetUtil.recursiveRelativeToAbsolutePath('C:\\root\\path', assets)).toStrictEqual(
-          absolutePathAssets
+          absolutePathAssets,
         );
       });
 
@@ -671,19 +702,19 @@ describe('services', () => {
               children: [
                 {
                   uri: 'https://api/a/b',
-                  type: 'api'
-                }
-              ]
+                  type: 'api',
+                },
+              ],
             },
             {
               uri: 'README.md',
-              type: 'file'
+              type: 'file',
             },
             {
               uri: 'b',
-              type: 'database'
-            }
-          ]
+              type: 'database',
+            },
+          ],
         };
         // This is the answer we expect
         const absolutePathAssets = {
@@ -696,22 +727,22 @@ describe('services', () => {
               children: [
                 {
                   uri: 'https://api/a/b',
-                  type: 'api'
-                }
-              ]
+                  type: 'api',
+                },
+              ],
             },
             {
               uri: '/root/path/README.md',
-              type: 'file'
+              type: 'file',
             },
             {
               uri: 'b',
-              type: 'database'
-            }
-          ]
+              type: 'database',
+            },
+          ],
         };
         expect(AssetUtil.recursiveRelativeToAbsolutePath('/root/path', assets)).toStrictEqual(
-          absolutePathAssets
+          absolutePathAssets,
         );
       });
 
@@ -726,19 +757,19 @@ describe('services', () => {
               children: [
                 {
                   uri: 'https://api/a/b',
-                  type: 'api'
-                }
-              ]
+                  type: 'api',
+                },
+              ],
             },
             {
               uri: 'README.md',
-              type: 'file'
+              type: 'file',
             },
             {
               uri: 'b',
-              type: 'database'
-            }
-          ]
+              type: 'database',
+            },
+          ],
         };
         // This is the answer we expect
         const absolutePathAssets = {
@@ -751,22 +782,22 @@ describe('services', () => {
               children: [
                 {
                   uri: 'https://api/a/b',
-                  type: 'api'
-                }
-              ]
+                  type: 'api',
+                },
+              ],
             },
             {
               uri: 'C:\\root\\path\\README.md',
-              type: 'file'
+              type: 'file',
             },
             {
               uri: 'b',
-              type: 'database'
-            }
-          ]
+              type: 'database',
+            },
+          ],
         };
         expect(AssetUtil.recursiveRelativeToAbsolutePath('C:\\root\\path', assets)).toStrictEqual(
-          absolutePathAssets
+          absolutePathAssets,
         );
       });
     });
@@ -793,7 +824,7 @@ describe('services', () => {
       it.onMac('should resolve the absolute path', () => {
         expect(AssetUtil.absoluteToRelativePath('/root/path', { uri: '/root/path/a' })).toBe('a');
         expect(AssetUtil.absoluteToRelativePath('/root/path', { uri: '/root/path/a/b/c/d' })).toBe(
-          'a/b/c/d'
+          'a/b/c/d',
         );
         // TODO: Need an assessment if this is a security risk and if we should restrict how we navigate
         // beyond the project root
@@ -801,15 +832,15 @@ describe('services', () => {
       });
       it.onWindows('should resolve the absolute path', () => {
         expect(
-          AssetUtil.absoluteToRelativePath('C:\\root\\path', { uri: 'C:\\root\\path\\a' })
+          AssetUtil.absoluteToRelativePath('C:\\root\\path', { uri: 'C:\\root\\path\\a' }),
         ).toBe('a');
         expect(
-          AssetUtil.absoluteToRelativePath('C:\\root\\path', { uri: 'C:\\root\\path\\a\\b\\c\\d' })
+          AssetUtil.absoluteToRelativePath('C:\\root\\path', { uri: 'C:\\root\\path\\a\\b\\c\\d' }),
         ).toBe('a/b/c/d');
         // TODO: Need an assessment if this is a security risk and if we should restrict how we navigate
         // beyond the project root
         expect(AssetUtil.absoluteToRelativePath('C:\\root\\path', { uri: 'C:\\root\\a' })).toBe(
-          '../a'
+          '../a',
         );
       });
     });
@@ -822,7 +853,7 @@ describe('services', () => {
 
       it('should return the asset object if the project path is not provided', () => {
         const assets = {
-          uri: '/tmp/root'
+          uri: '/tmp/root',
         };
         expect(AssetUtil.recursiveAbsoluteToRelativePath(null, assets)).toBe(assets);
         expect(AssetUtil.recursiveAbsoluteToRelativePath(undefined, assets)).toBe(assets);
@@ -839,15 +870,15 @@ describe('services', () => {
               children: [
                 {
                   uri: 'a/b',
-                  type: 'file'
-                }
-              ]
+                  type: 'file',
+                },
+              ],
             },
             {
               uri: 'b',
-              type: 'file'
-            }
-          ]
+              type: 'file',
+            },
+          ],
         };
         // This is the answer we expect
         const absolutePathAssets = {
@@ -860,18 +891,18 @@ describe('services', () => {
               children: [
                 {
                   uri: '/root/path/a/b',
-                  type: 'file'
-                }
-              ]
+                  type: 'file',
+                },
+              ],
             },
             {
               uri: '/root/path/b',
-              type: 'file'
-            }
-          ]
+              type: 'file',
+            },
+          ],
         };
         expect(
-          AssetUtil.recursiveAbsoluteToRelativePath('/root/path', absolutePathAssets)
+          AssetUtil.recursiveAbsoluteToRelativePath('/root/path', absolutePathAssets),
         ).toStrictEqual(relativePathAssets);
       });
       it.onWindows('should make all absolute paths into relative paths', () => {
@@ -885,15 +916,15 @@ describe('services', () => {
               children: [
                 {
                   uri: 'a/b',
-                  type: 'file'
-                }
-              ]
+                  type: 'file',
+                },
+              ],
             },
             {
               uri: 'b',
-              type: 'file'
-            }
-          ]
+              type: 'file',
+            },
+          ],
         };
         // This is the answer we expect
         const absolutePathAssets = {
@@ -906,18 +937,18 @@ describe('services', () => {
               children: [
                 {
                   uri: 'C:\\root\\path\\a\\b',
-                  type: 'file'
-                }
-              ]
+                  type: 'file',
+                },
+              ],
             },
             {
               uri: 'C:\\root\\path\\b',
-              type: 'file'
-            }
-          ]
+              type: 'file',
+            },
+          ],
         };
         expect(
-          AssetUtil.recursiveAbsoluteToRelativePath('C:\\root\\path', absolutePathAssets)
+          AssetUtil.recursiveAbsoluteToRelativePath('C:\\root\\path', absolutePathAssets),
         ).toStrictEqual(relativePathAssets);
       });
 
@@ -932,19 +963,19 @@ describe('services', () => {
               children: [
                 {
                   uri: 'https://api/a/b',
-                  type: 'api'
-                }
-              ]
+                  type: 'api',
+                },
+              ],
             },
             {
               uri: 'README.md',
-              type: 'file'
+              type: 'file',
             },
             {
               uri: 'b',
-              type: 'database'
-            }
-          ]
+              type: 'database',
+            },
+          ],
         };
         // This is the answer we expect
         const absolutePathAssets = {
@@ -957,22 +988,22 @@ describe('services', () => {
               children: [
                 {
                   uri: 'https://api/a/b',
-                  type: 'api'
-                }
-              ]
+                  type: 'api',
+                },
+              ],
             },
             {
               uri: '/root/path/README.md',
-              type: 'file'
+              type: 'file',
             },
             {
               uri: 'b',
-              type: 'database'
-            }
-          ]
+              type: 'database',
+            },
+          ],
         };
         expect(
-          AssetUtil.recursiveAbsoluteToRelativePath('/root/path', absolutePathAssets)
+          AssetUtil.recursiveAbsoluteToRelativePath('/root/path', absolutePathAssets),
         ).toStrictEqual(relativePathAssets);
       });
       it.onWindows('should not modify non-file and non-directory entries', () => {
@@ -986,19 +1017,19 @@ describe('services', () => {
               children: [
                 {
                   uri: 'https://api/a/b',
-                  type: 'api'
-                }
-              ]
+                  type: 'api',
+                },
+              ],
             },
             {
               uri: 'README.md',
-              type: 'file'
+              type: 'file',
             },
             {
               uri: 'b',
-              type: 'database'
-            }
-          ]
+              type: 'database',
+            },
+          ],
         };
         // This is the answer we expect
         const absolutePathAssets = {
@@ -1011,22 +1042,22 @@ describe('services', () => {
               children: [
                 {
                   uri: 'https://api/a/b',
-                  type: 'api'
-                }
-              ]
+                  type: 'api',
+                },
+              ],
             },
             {
               uri: 'C:\\root\\path\\README.md',
-              type: 'file'
+              type: 'file',
             },
             {
               uri: 'b',
-              type: 'database'
-            }
-          ]
+              type: 'database',
+            },
+          ],
         };
         expect(
-          AssetUtil.recursiveAbsoluteToRelativePath('C:\\root\\path', absolutePathAssets)
+          AssetUtil.recursiveAbsoluteToRelativePath('C:\\root\\path', absolutePathAssets),
         ).toStrictEqual(relativePathAssets);
       });
     });
@@ -1041,136 +1072,136 @@ describe('services', () => {
         const absolutePathAssets = [
           {
             uri: '/root/path',
-            type: 'directory'
+            type: 'directory',
           },
           {
             uri: 'https://api/a/b',
-            type: 'api'
+            type: 'api',
           },
           {
             uri: 'b',
-            type: 'database'
-          }
+            type: 'database',
+          },
         ];
         // This is the answer we expect
         const relativePathAssets = [
           {
             uri: '',
-            type: 'directory'
+            type: 'directory',
           },
           {
             uri: 'https://api/a/b',
-            type: 'api'
+            type: 'api',
           },
           {
             uri: 'b',
-            type: 'database'
-          }
+            type: 'database',
+          },
         ];
         expect(
-          AssetUtil.absoluteToRelativePathForArray('/root/path', absolutePathAssets)
+          AssetUtil.absoluteToRelativePathForArray('/root/path', absolutePathAssets),
         ).toStrictEqual(relativePathAssets);
       });
       it.onWindows('should not modify non-file and non-directory entries', () => {
         const absolutePathAssets = [
           {
             uri: 'C:\\root\\path',
-            type: 'directory'
+            type: 'directory',
           },
           {
             uri: 'https://api/a/b',
-            type: 'api'
+            type: 'api',
           },
           {
             uri: 'b',
-            type: 'database'
-          }
+            type: 'database',
+          },
         ];
         // This is the answer we expect
         const relativePathAssets = [
           {
             uri: '',
-            type: 'directory'
+            type: 'directory',
           },
           {
             uri: 'https://api/a/b',
-            type: 'api'
+            type: 'api',
           },
           {
             uri: 'b',
-            type: 'database'
-          }
+            type: 'database',
+          },
         ];
         expect(
-          AssetUtil.absoluteToRelativePathForArray('C:\\root\\path', absolutePathAssets)
+          AssetUtil.absoluteToRelativePathForArray('C:\\root\\path', absolutePathAssets),
         ).toStrictEqual(relativePathAssets);
       });
       it.onMac('should modify file and directory entries', () => {
         const absolutePathAssets = [
           {
             uri: '/root/path',
-            type: Constants.AssetType.DIRECTORY
+            type: Constants.AssetType.DIRECTORY,
           },
           {
             uri: '/root/path/folder',
-            type: Constants.AssetType.FOLDER // Testing the alias for directory
+            type: Constants.AssetType.FOLDER, // Testing the alias for directory
           },
           {
             uri: '/root/path/folder/file',
-            type: Constants.AssetType.FILE
-          }
+            type: Constants.AssetType.FILE,
+          },
         ];
         // This is the answer we expect
         const relativePathAssets = [
           {
             uri: '',
-            type: Constants.AssetType.DIRECTORY
+            type: Constants.AssetType.DIRECTORY,
           },
           {
             uri: 'folder',
-            type: Constants.AssetType.FOLDER
+            type: Constants.AssetType.FOLDER,
           },
           {
             uri: 'folder/file',
-            type: Constants.AssetType.FILE
-          }
+            type: Constants.AssetType.FILE,
+          },
         ];
         expect(
-          AssetUtil.absoluteToRelativePathForArray('/root/path', absolutePathAssets)
+          AssetUtil.absoluteToRelativePathForArray('/root/path', absolutePathAssets),
         ).toStrictEqual(relativePathAssets);
       });
       it.onWindows('should modify file and directory entries', () => {
         const absolutePathAssets = [
           {
             uri: 'C:\\root\\path',
-            type: Constants.AssetType.DIRECTORY
+            type: Constants.AssetType.DIRECTORY,
           },
           {
             uri: 'C:\\root\\path\\folder',
-            type: Constants.AssetType.FOLDER // Testing the alias for directory
+            type: Constants.AssetType.FOLDER, // Testing the alias for directory
           },
           {
             uri: 'C:\\root\\path\\folder\\file',
-            type: Constants.AssetType.FILE
-          }
+            type: Constants.AssetType.FILE,
+          },
         ];
         // This is the answer we expect
         const relativePathAssets = [
           {
             uri: '',
-            type: Constants.AssetType.DIRECTORY
+            type: Constants.AssetType.DIRECTORY,
           },
           {
             uri: 'folder',
-            type: Constants.AssetType.FOLDER
+            type: Constants.AssetType.FOLDER,
           },
           {
             uri: 'folder/file', // Note that we are normalizing to POSIX paths, so this is correct for Windows
-            type: Constants.AssetType.FILE
-          }
+            type: Constants.AssetType.FILE,
+          },
         ];
         expect(
-          AssetUtil.absoluteToRelativePathForArray('C:\\root\\path', absolutePathAssets)
+          AssetUtil.absoluteToRelativePathForArray('C:\\root\\path', absolutePathAssets),
         ).toStrictEqual(relativePathAssets);
       });
     });
@@ -1185,136 +1216,136 @@ describe('services', () => {
         const absolutePathAssets = [
           {
             uri: '/root/path',
-            type: 'directory'
+            type: 'directory',
           },
           {
             uri: 'https://api/a/b',
-            type: 'api'
+            type: 'api',
           },
           {
             uri: 'b',
-            type: 'database'
-          }
+            type: 'database',
+          },
         ];
         // This is the answer we expect
         const relativePathAssets = [
           {
             uri: '',
-            type: 'directory'
+            type: 'directory',
           },
           {
             uri: 'https://api/a/b',
-            type: 'api'
+            type: 'api',
           },
           {
             uri: 'b',
-            type: 'database'
-          }
+            type: 'database',
+          },
         ];
         expect(
-          AssetUtil.relativeToAbsolutePathForArray('/root/path', relativePathAssets)
+          AssetUtil.relativeToAbsolutePathForArray('/root/path', relativePathAssets),
         ).toStrictEqual(absolutePathAssets);
       });
       it.onWindows('should not modify non-file and non-directory entries', () => {
         const absolutePathAssets = [
           {
             uri: 'C:\\root\\path',
-            type: 'directory'
+            type: 'directory',
           },
           {
             uri: 'https://api/a/b',
-            type: 'api'
+            type: 'api',
           },
           {
             uri: 'b',
-            type: 'database'
-          }
+            type: 'database',
+          },
         ];
         // This is the answer we expect
         const relativePathAssets = [
           {
             uri: '',
-            type: 'directory'
+            type: 'directory',
           },
           {
             uri: 'https://api/a/b',
-            type: 'api'
+            type: 'api',
           },
           {
             uri: 'b',
-            type: 'database'
-          }
+            type: 'database',
+          },
         ];
         expect(
-          AssetUtil.relativeToAbsolutePathForArray('C:\\root\\path', relativePathAssets)
+          AssetUtil.relativeToAbsolutePathForArray('C:\\root\\path', relativePathAssets),
         ).toStrictEqual(absolutePathAssets);
       });
       it.onMac('should modify file and directory entries', () => {
         const absolutePathAssets = [
           {
             uri: '/root/path',
-            type: Constants.AssetType.DIRECTORY
+            type: Constants.AssetType.DIRECTORY,
           },
           {
             uri: '/root/path/folder',
-            type: Constants.AssetType.FOLDER // Testing the alias for directory
+            type: Constants.AssetType.FOLDER, // Testing the alias for directory
           },
           {
             uri: '/root/path/folder/file',
-            type: Constants.AssetType.FILE
-          }
+            type: Constants.AssetType.FILE,
+          },
         ];
         // This is the answer we expect
         const relativePathAssets = [
           {
             uri: '',
-            type: Constants.AssetType.DIRECTORY
+            type: Constants.AssetType.DIRECTORY,
           },
           {
             uri: 'folder',
-            type: Constants.AssetType.FOLDER
+            type: Constants.AssetType.FOLDER,
           },
           {
             uri: 'folder/file',
-            type: Constants.AssetType.FILE
-          }
+            type: Constants.AssetType.FILE,
+          },
         ];
         expect(
-          AssetUtil.relativeToAbsolutePathForArray('/root/path', relativePathAssets)
+          AssetUtil.relativeToAbsolutePathForArray('/root/path', relativePathAssets),
         ).toStrictEqual(absolutePathAssets);
       });
       it.onWindows('should modify file and directory entries', () => {
         const absolutePathAssets = [
           {
             uri: 'C:\\root\\path',
-            type: Constants.AssetType.DIRECTORY
+            type: Constants.AssetType.DIRECTORY,
           },
           {
             uri: 'C:\\root\\path\\folder',
-            type: Constants.AssetType.FOLDER // Testing the alias for directory
+            type: Constants.AssetType.FOLDER, // Testing the alias for directory
           },
           {
             uri: 'C:\\root\\path\\folder\\file',
-            type: Constants.AssetType.FILE
-          }
+            type: Constants.AssetType.FILE,
+          },
         ];
         // This is the answer we expect
         const relativePathAssets = [
           {
             uri: '',
-            type: Constants.AssetType.DIRECTORY
+            type: Constants.AssetType.DIRECTORY,
           },
           {
             uri: 'folder',
-            type: Constants.AssetType.FOLDER
+            type: Constants.AssetType.FOLDER,
           },
           {
             uri: 'folder\\file',
-            type: Constants.AssetType.FILE
-          }
+            type: Constants.AssetType.FILE,
+          },
         ];
         expect(
-          AssetUtil.relativeToAbsolutePathForArray('C:\\root\\path', relativePathAssets)
+          AssetUtil.relativeToAbsolutePathForArray('C:\\root\\path', relativePathAssets),
         ).toStrictEqual(absolutePathAssets);
       });
     });


### PR DESCRIPTION
# Changes Summary
This PR introduces a feature to display the project's entrypoints list. As explained in the issue #192, it incorporates functionality to navigate directly to a selected entrypoint node in the asset tree with a button click.

The UI design of the component was up to my imagination, though I tried to make it compatible with the app UI standards. Suggestions for further improvements are welcome :)

Note: The responsiveness of the component is similar to that of the asset details component. While not a significant issue, you may observe slight hanging in the center, for specific aspect ratios, in the video demo below. This is due to the space reserved for the details component, which appears upon selecting an asset. Overall, everything appears to be functioning properly at this time. This behavior primarily stems from the use of inline-block display, which is also used in the details component.

## Attachments

https://github.com/StatTag/StatWrap/assets/96688318/fe34872d-4ca2-4ef8-aec2-750fc488fb51

_Video Demonstration of the Entrypoints component_

## Related Issue 🚀 
Closes #192  

## Checklist ✅ 
- [x] Implemented all required changes specified in the related feature request.
- [x] The component functions properly, with UI responsiveness across various devices.
- [x] The tree expands recursively and smoothly upon navigating to an entrypoint asset node.
- [x] Locally tested all changes to ensure functionality.

## Reviewer
@lrasmus 