### PR TITLE
(Feat) : Added Cancel button when editing project details from Dashboard

### DIFF
--- a/app/components/Project/About/About.css
+++ b/app/components/Project/About/About.css
@@ -21,7 +21,6 @@
 
 .tagViewer {
   padding-bottom: 25px;
-  float: left;
 }
 
 .button {

--- a/app/components/Project/About/About.css
+++ b/app/components/Project/About/About.css
@@ -15,9 +15,13 @@
   font-size: 0.9rem;
 }
 
-.propertyBlock,
+.propertyBlock {
+  padding-bottom: 25px;
+}
+
 .tagViewer {
   padding-bottom: 25px;
+  float: left;
 }
 
 .button {

--- a/app/components/Project/About/About.js
+++ b/app/components/Project/About/About.js
@@ -1,5 +1,13 @@
-import React, { useState } from 'react';
-import { Button, Box } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+import {
+  Button,
+  Box,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import gfm from 'remark-gfm';
 import PropTypes from 'prop-types';
@@ -15,28 +23,33 @@ import { DescriptionContentType } from '../../../constants/constants';
 
 function about(props) {
   const [editing, setEditing] = useState(false);
-  const [descriptionEditor, setDescriptionEditor] = useState(
-    props.project.description && props.project.description.contentType
-      ? props.project.description.contentType
-      : DescriptionContentType.MARKDOWN,
-  );
-  const [descriptionText, setDescriptionText] = useState(
-    props.project.description && props.project.description.uri
-      ? props.project.description.uriContent
-      : props.project.description && props.project.description.content
-        ? props.project.description.content
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [initialState, setInitialState] = useState({
+    descriptionEditor:
+      props.project.description && props.project.description.contentType
+        ? props.project.description.contentType
+        : DescriptionContentType.MARKDOWN,
+    descriptionText:
+      props.project.description && props.project.description.uri
+        ? props.project.description.uriContent
+        : props.project.description && props.project.description.content
+          ? props.project.description.content
+          : '',
+    descriptionUri:
+      props.project.description && props.project.description.uri
+        ? props.project.description.uri
         : '',
-  );
-  const [descriptionUri, setDescriptionUri] = useState(
-    props.project.description && props.project.description.uri ? props.project.description.uri : '',
-  );
-  const [categories, setCategories] = useState(
-    props.project.categories ? props.project.categories : [],
-  );
-  const [notes, setNotes] = useState(props.project.notes ? props.project.notes : []);
+    categories: props.project.categories ? props.project.categories : [],
+    notes: props.project.notes ? props.project.notes : [],
+  });
 
-  // Derive updated state from props
-  React.useEffect(() => {
+  const [descriptionEditor, setDescriptionEditor] = useState(initialState.descriptionEditor);
+  const [descriptionText, setDescriptionText] = useState(initialState.descriptionText);
+  const [descriptionUri, setDescriptionUri] = useState(initialState.descriptionUri);
+  const [categories, setCategories] = useState(initialState.categories);
+  const [notes, setNotes] = useState(initialState.notes);
+
+  useEffect(() => {
     setDescriptionText(
       props.project.description && props.project.description.uri
         ? props.project.description.uriContent
@@ -45,17 +58,20 @@ function about(props) {
           : '',
     );
   }, [props.project.description]);
-  React.useEffect(() => {
+
+  useEffect(() => {
     setDescriptionUri(
       props.project.description && props.project.description.uri
         ? props.project.description.uri
         : '',
     );
   }, [props.project.description]);
-  React.useEffect(() => {
+
+  useEffect(() => {
     setCategories(props.project.categories ? props.project.categories : []);
   }, [props.project.categories]);
-  React.useEffect(() => {
+
+  useEffect(() => {
     setNotes(props.project.notes ? props.project.notes : []);
   }, [props.project.notes]);
 
@@ -80,18 +96,41 @@ function about(props) {
     );
   };
 
-  const handleButtonToggled = () => {
-    const currentStatus = editing;
-    setEditing(!currentStatus);
+  const handleSave = () => {
+    setEditing(false);
+    props.onUpdateDetails(
+      descriptionText,
+      descriptionEditor === DescriptionContentType.URI ? descriptionUri : null,
+      categories,
+    );
+  };
 
-    // If we're back to view mode, trigger a save of the data
-    if (currentStatus) {
-      props.onUpdateDetails(
-        descriptionText,
-        descriptionEditor === DescriptionContentType.URI ? descriptionUri : null,
-        categories,
-      );
+  const handleCancel = () => {
+    if (hasUnsavedChanges()) {
+      setShowCancelDialog(true);
+    } else {
+      revertChanges();
     }
+  };
+
+  const revertChanges = () => {
+    setDescriptionEditor(initialState.descriptionEditor);
+    setDescriptionText(initialState.descriptionText);
+    setDescriptionUri(initialState.descriptionUri);
+    setCategories(initialState.categories);
+    setNotes(initialState.notes);
+    setEditing(false);
+    setShowCancelDialog(false);
+  };
+
+  const hasUnsavedChanges = () => {
+    return (
+      descriptionEditor !== initialState.descriptionEditor ||
+      descriptionText !== initialState.descriptionText ||
+      descriptionUri !== initialState.descriptionUri ||
+      JSON.stringify(categories) !== JSON.stringify(initialState.categories) ||
+      JSON.stringify(notes) !== JSON.stringify(initialState.notes)
+    );
   };
 
   const updatedNoteHandler = (note, text) => {
@@ -111,9 +150,7 @@ function about(props) {
   };
 
   let view = null;
-  let buttonLabel = '';
   if (editing) {
-    buttonLabel = 'Save Details';
     let descriptionControl = null;
     let descriptionEditorButtonLabel = null;
     if (descriptionEditor === DescriptionContentType.URI) {
@@ -159,7 +196,6 @@ function about(props) {
       </Box>
     );
   } else {
-    buttonLabel = 'Edit Details';
     let tagViewerControl = null;
     if (categories && categories.length > 0) {
       tagViewerControl = <TagViewer className={styles.tagViewer} tags={categories} />;
@@ -192,16 +228,61 @@ function about(props) {
 
   return (
     <div className={styles.container}>
-      <Button
-        className={styles.button}
-        variant="outlined"
-        color="primary"
-        size="small"
-        onClick={handleButtonToggled}
-      >
-        {buttonLabel}
-      </Button>
+      {editing ? (
+        <>
+          <Button
+            className={styles.button}
+            variant="outlined"
+            color="secondary"
+            size="small"
+            onClick={handleCancel}
+            style={{ marginTop: '32px' }}
+          >
+            Cancel
+          </Button>
+          <Button
+            className={styles.button}
+            variant="outlined"
+            color="primary"
+            size="small"
+            onClick={handleSave}
+            style={{
+              marginTop: '32px',
+              marginLeft: '20px',
+              marginRight: '20px',
+            }}
+          >
+            Save Details
+          </Button>
+        </>
+      ) : (
+        <Button
+          className={styles.button}
+          variant="outlined"
+          color="primary"
+          size="small"
+          onClick={() => setEditing(true)}
+        >
+          Edit Details
+        </Button>
+      )}
       {view}
+      <Dialog open={showCancelDialog} onClose={() => setShowCancelDialog(false)}>
+        <DialogTitle style={{ color: 'white' }}>Discard Changes?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            You have made changes. Do you wish to discard those changes?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={revertChanges} color="primary">
+            Yes
+          </Button>
+          <Button onClick={() => setShowCancelDialog(false)} color="secondary">
+            No
+          </Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 }

--- a/app/components/Project/About/About.js
+++ b/app/components/Project/About/About.js
@@ -21,9 +21,10 @@ import LinkedDescription from '../LinkedDescription/LinkedDescription';
 import ProjectUpdateSummary from '../ProjectUpdateSummary/ProjectUpdateSummary';
 import { DescriptionContentType } from '../../../constants/constants';
 
-function about(props) {
+function About(props) {
   const [editing, setEditing] = useState(false);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
+
   const [initialState, setInitialState] = useState({
     descriptionEditor:
       props.project.description && props.project.description.contentType
@@ -42,6 +43,34 @@ function about(props) {
     categories: props.project.categories ? props.project.categories : [],
     notes: props.project.notes ? props.project.notes : [],
   });
+
+  useEffect(() => {
+    const newState = {
+      descriptionEditor:
+        props.project.description && props.project.description.contentType
+          ? props.project.description.contentType
+          : DescriptionContentType.MARKDOWN,
+      descriptionText:
+        props.project.description && props.project.description.uri
+          ? props.project.description.uriContent
+          : props.project.description && props.project.description.content
+            ? props.project.description.content
+            : '',
+      descriptionUri:
+        props.project.description && props.project.description.uri
+          ? props.project.description.uri
+          : '',
+      categories: props.project.categories ? props.project.categories : [],
+      notes: props.project.notes ? props.project.notes : [],
+    };
+
+    setInitialState(newState);
+    setDescriptionEditor(newState.descriptionEditor);
+    setDescriptionText(newState.descriptionText);
+    setDescriptionUri(newState.descriptionUri);
+    setCategories(newState.categories);
+    setNotes(newState.notes);
+  }, [props.project]);
 
   const [descriptionEditor, setDescriptionEditor] = useState(initialState.descriptionEditor);
   const [descriptionText, setDescriptionText] = useState(initialState.descriptionText);
@@ -287,7 +316,7 @@ function about(props) {
   );
 }
 
-about.propTypes = {
+About.propTypes = {
   project: PropTypes.object.isRequired,
   updates: PropTypes.object,
   onUpdateDetails: PropTypes.func.isRequired,
@@ -297,4 +326,4 @@ about.propTypes = {
   onClickUpdatesLink: PropTypes.func,
 };
 
-export default about;
+export default About;


### PR DESCRIPTION
# Summary of Changes

This pull request aims to enhance the user experience when editing project details in StatWrap by adding a "Cancel" button that allows users to discard any changes made and revert to the original view.

**Changes:**

- Added a "Cancel" button to the right of the "Save Details" button.
- Implemented functionality to discard any edits when the "Cancel" button is clicked.
- Added a prompt to alert users if they have unsaved changes when they click "Cancel", asking "You have made changes. Do you wish to discard those changes?"
- Ensured that clicking "Cancel" exits the editing interface and returns the user to the Dashboard view.

## Related Issue

Closes #167 

## Checklist

- [x] My code is well-documented, and I've updated relevant documentation.
- [x] I have tested these changes on my local environment.
- [x] I have reviewed and proofread my code and the changes.
- [x] The branch is up-to-date with the base branch.

## Additional Context

https://github.com/StatTag/StatWrap/assets/64387054/7838c50d-856d-4f84-83ef-87dcae5527ef

## Reviewer(s)

@lrasmus