### PR TITLE
Refactors the code and implements unit tests for the checklist utility and service

### DIFF
--- a/app/components/ReproChecklist/ChecklistItem/ChecklistItem.js
+++ b/app/components/ReproChecklist/ChecklistItem/ChecklistItem.js
@@ -78,6 +78,8 @@ function ChecklistItem(props) {
     }
 
     setAddAsset(false);
+    setAssetTitle('');
+    setAssetDescription('');
   }
 
   const handleCopy = (urlId, hyperlink) => {
@@ -305,7 +307,7 @@ function ChecklistItem(props) {
                 <div className={`${styles.imageContent} ${showImages ? styles.show : ''}`}>
                   <ul>
                     {item.images.map((image) => (
-                      <li key={image} className={styles.image}>
+                      <li key={image.id} className={styles.image}>
                         <div className={styles.imageHeader}>
                           <span className={styles.imageText}>{image.title}</span>
                           <Delete
@@ -389,7 +391,7 @@ function ChecklistItem(props) {
 
 ChecklistItem.propTypes = {
   item: PropTypes.shape({
-    id: PropTypes.string.isRequired,
+    id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
     statement: PropTypes.string.isRequired,
     answer: PropTypes.bool.isRequired,

--- a/app/components/ReproChecklist/ReproChecklist.js
+++ b/app/components/ReproChecklist/ReproChecklist.js
@@ -3,78 +3,16 @@ import PropTypes from 'prop-types';
 import styles from './ReproChecklist.css';
 import ChecklistItem from './ChecklistItem/ChecklistItem';
 import Error from '../Error/Error';
-import Constants from '../../constants/constants';
 import { Typography, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
 import { SaveAlt } from '@mui/icons-material';
 import pdfMake from 'pdfmake/build/pdfmake';
 import pdfFonts from 'pdfmake/build/vfs_fonts';
+import GeneralUtil from '../../utils/general';
+import ChecklistUtil from '../../utils/checklist';
 
 pdfMake.vfs = pdfFonts.pdfMake.vfs;
 
 const path = require('path');
-const fs = require('fs');
-const AssetsConfig = require('../../constants/assets-config');
-
-const languages = {};
-const dependencies = {};
-const imageAssets = {};
-
-function findAssetLanguagesAndDependencies(asset) {
-  if (asset.type === Constants.AssetType.FILE && asset.contentTypes.includes(Constants.AssetContentType.CODE) ) {
-    const lastSep = asset.uri.lastIndexOf(path.sep);
-    const fileName = asset.uri.substring(lastSep + 1);
-    const ext = fileName.split('.').pop();
-    if(ext){
-      AssetsConfig.contentTypes.forEach((contentType) => {
-        if(contentType.extensions.includes(ext)) {
-          languages[contentType.name] = true;
-        }
-      });
-    }
-  }
-
-  if(asset.children){
-    asset.children.forEach(findAssetLanguagesAndDependencies);
-  }
-
-  return {
-    languages: Object.keys(languages),
-    dependencies: Object.keys(dependencies)
-  };
-}
-
-function convertImageToBase64(filePath) {
-  try {
-    const file = fs.readFileSync(filePath);
-    const ext = path.extname(filePath).toLowerCase();
-    let mimeType;
-    switch (ext) {
-      case '.jpg':
-      case '.jpeg':
-        mimeType = 'image/jpeg';
-        break;
-      case '.png':
-        mimeType = 'image/png';
-        break;
-      case '.gif':
-        mimeType = 'image/gif';
-        break;
-      case '.webp':
-        mimeType = 'image/webp';
-        break;
-      case '.svg':
-        mimeType = 'image/svg+xml';
-        break;
-      default:
-        mimeType = 'application/octet-stream';
-    }
-    return `data:${mimeType};base64,${file.toString('base64')}`;
-  } catch (error) {
-    console.error('Error converting image to Base64:', error);
-    return null;
-  }
-};
-
 
 function ReproChecklist(props) {
   const { project, checklist, error, onUpdated, onAddedNote, onUpdatedNote, onDeletedNote, onSelectedAsset} = props;
@@ -83,7 +21,7 @@ function ReproChecklist(props) {
   useEffect(() => {
     if (project && checklist && !error) {
       if(project.assets) {
-        const scanResult1 = findAssetLanguagesAndDependencies(project.assets);
+        const scanResult1 = ChecklistUtil.findAssetLanguagesAndDependencies(project.assets);
         checklist[0].scanResult = scanResult1;
       }
     }
@@ -97,8 +35,8 @@ function ReproChecklist(props) {
   };
 
   const handleReportGeneration = (exportNotes) => {
-    const checkedIcon = convertImageToBase64(path.join(__dirname, 'images/yes.png'));
-    const statWrapLogo = convertImageToBase64(path.join(__dirname, 'images/banner.png'));
+    const checkedIcon = GeneralUtil.convertImageToBase64(path.join(__dirname, 'images/yes.png'));
+    const statWrapLogo = GeneralUtil.convertImageToBase64(path.join(__dirname, 'images/banner.png'));
 
     const documentDefinition = {
       content: [

--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -36,6 +36,7 @@ module.exports = {
 
   StatWrapFiles: {
     BASE_FOLDER: '.statwrap',
+    PROJECT: '.statwrap-project.json',
     LOG: '.statwrap.log',
     CHECKLIST: '.statwrap-checklist.json',
   },

--- a/app/services/assets/handlers/file.js
+++ b/app/services/assets/handlers/file.js
@@ -13,7 +13,7 @@ const FILE_IGNORE_LIST = [
   '.DS_Store',
   'Thumbs.db',
   '.keep', // We use these within our template projects
-  '.statwrap-project.json', // ProjectService DefaultProjectFile -- circular dependency, so we need to use literal
+  Constants.StatWrapFiles.PROJECT,
   StatWrapFiles.LOG,
   StatWrapFiles.BASE_FOLDER,
   '.git',

--- a/app/services/project.js
+++ b/app/services/project.js
@@ -13,11 +13,10 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const DefaultProjectFile = '.statwrap-project.json';
 const ProjectFileFormatVersion = '1';
 const MaximumFolderNameLength = 255;
 
-export { DefaultProjectFile, ProjectFileFormatVersion };
+export { ProjectFileFormatVersion };
 
 export default class ProjectService {
   /**
@@ -89,9 +88,9 @@ export default class ProjectService {
 
   lockProjectFile(projectPath) {
     const filePath = path.join(
-      projectPath.replace('~', os.homedir),
+      projectPath.replace('~', os.homedir()),
       Constants.StatWrapFiles.BASE_FOLDER,
-      DefaultProjectFile,
+      Constants.StatWrapFiles.PROJECT,
     );
 
     lockfile.lockSync(filePath);
@@ -99,9 +98,9 @@ export default class ProjectService {
 
   unlockProjectFile(projectPath) {
     const filePath = path.join(
-      projectPath.replace('~', os.homedir),
+      projectPath.replace('~', os.homedir()),
       Constants.StatWrapFiles.BASE_FOLDER,
-      DefaultProjectFile,
+      Constants.StatWrapFiles.PROJECT,
     );
 
     lockfile.unlockSync(filePath);
@@ -112,9 +111,9 @@ export default class ProjectService {
   // name should not be specified as part of projectPath.
   loadProjectFile(projectPath) {
     const filePath = path.join(
-      projectPath.replace('~', os.homedir),
+      projectPath.replace('~', os.homedir()),
       Constants.StatWrapFiles.BASE_FOLDER,
-      DefaultProjectFile,
+      Constants.StatWrapFiles.PROJECT,
     );
 
     try {
@@ -174,7 +173,7 @@ export default class ProjectService {
     // This will handle if someone is trying to configure what they think is a new project,
     // but it actually already exists
     const configFolderPath = path.join(
-      projectPath.replace('~', os.homedir),
+      projectPath.replace('~', os.homedir()),
       Constants.StatWrapFiles.BASE_FOLDER,
     );
     try {
@@ -183,7 +182,7 @@ export default class ProjectService {
       fs.mkdirSync(configFolderPath, { recursive: true });
     }
 
-    const filePath = path.join(configFolderPath, DefaultProjectFile);
+    const filePath = path.join(configFolderPath, Constants.StatWrapFiles.PROJECT);
     fs.writeFileSync(filePath, JSON.stringify(this.stripExtraProjectData(project)));
   }
 
@@ -233,7 +232,7 @@ export default class ProjectService {
         // appended to the root folder.
         const sanitizedName = this.sanitizeFolderName(project.name);
         const projectDirectory = path.join(
-          project.directory.replace('~', os.homedir),
+          project.directory.replace('~', os.homedir()),
           sanitizedName,
         );
         validationReport.project.name = project.name;

--- a/app/utils/checklist.js
+++ b/app/utils/checklist.js
@@ -1,4 +1,6 @@
 import Constants from '../constants/constants';
+import AssetsConfig from '../constants/assets-config';
+const path = require('path');
 
 export default class ChecklistUtil {
   static initializeChecklist() {
@@ -17,5 +19,32 @@ export default class ChecklistUtil {
       });
     });
     return checklist;
+  }
+
+  static findAssetLanguagesAndDependencies(asset, languages = {}, dependencies = {}) {
+    if (asset.type === Constants.AssetType.FILE && asset.contentTypes.includes(Constants.AssetContentType.CODE) ) {
+      const lastSep = asset.uri.lastIndexOf(path.sep);
+      const fileName = asset.uri.substring(lastSep + 1);
+      const ext = fileName.split('.').pop();
+
+      if(ext){
+        AssetsConfig.contentTypes.forEach((contentType) => {
+          if(contentType.extensions.includes(ext)) {
+            languages[contentType.name] = true;
+          }
+        });
+      }
+    }
+
+    if(asset.children){
+      asset.children.forEach(child => {
+        this.findAssetLanguagesAndDependencies(child, languages, dependencies);
+      });
+    }
+
+    return {
+      languages: Object.keys(languages),
+      dependencies: Object.keys(dependencies)
+    };
   }
 }

--- a/app/utils/general.js
+++ b/app/utils/general.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 const DefaultDisplayName = '(empty)';
+const path = require('path');
+const fs = require('fs');
 
 export default class GeneralUtil {
   static formatDateTime(date) {
@@ -152,4 +154,36 @@ export default class GeneralUtil {
       };
     }, []);
   }
+
+  static convertImageToBase64(filePath) {
+    try {
+      const file = fs.readFileSync(filePath);
+      const ext = path.extname(filePath).toLowerCase();
+      let mimeType;
+      switch (ext) {
+        case '.jpg':
+        case '.jpeg':
+          mimeType = 'image/jpeg';
+          break;
+        case '.png':
+          mimeType = 'image/png';
+          break;
+        case '.gif':
+          mimeType = 'image/gif';
+          break;
+        case '.webp':
+          mimeType = 'image/webp';
+          break;
+        case '.svg':
+          mimeType = 'image/svg+xml';
+          break;
+        default:
+          mimeType = 'application/octet-stream';
+      }
+      return `data:${mimeType};base64,${file.toString('base64')}`;
+    } catch (error) {
+      console.error('Error converting image to Base64:', error);
+      return null;
+    }
+  };
 }

--- a/test/services/assets/handlers/file.spec.js
+++ b/test/services/assets/handlers/file.spec.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import FileHandler from '../../../../app/services/assets/handlers/file';
+import Constants from '../../../../app/constants/constants';
 
 jest.mock('fs');
 jest.mock('os');
@@ -30,7 +31,7 @@ describe('services', () => {
         const handler = new FileHandler();
         expect(handler.includeFile('/User/test/Project/.DS_Store')).toBeFalsy();
         expect(handler.includeFile('C:/test/Project/Thumbs.db')).toBeFalsy();
-        expect(handler.includeFile('.statwrap-project.json')).toBeFalsy();
+        expect(handler.includeFile(Constants.StatWrapFiles.PROJECT)).toBeFalsy();
       });
 
       it('should include allowable files and folders', () => {

--- a/test/services/assets/handlers/python.spec.js
+++ b/test/services/assets/handlers/python.spec.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import PythonHandler from '../../../../app/services/assets/handlers/python';
+import Constants from '../../../../app/constants/constants';
 
 jest.mock('fs');
 jest.mock('os');
@@ -30,7 +31,7 @@ describe('services', () => {
         const handler = new PythonHandler();
         expect(handler.includeFile('/User/test/Project/python')).toBeFalsy();
         expect(handler.includeFile('C:/test/Project/Thumbs.db')).toBeFalsy();
-        expect(handler.includeFile('.statwrap-project.json')).toBeFalsy();
+        expect(handler.includeFile(Constants.StatWrapFiles.PROJECT)).toBeFalsy();
       });
 
       it('should exclude where Python extension exists but is not the last', () => {

--- a/test/services/assets/handlers/r.spec.js
+++ b/test/services/assets/handlers/r.spec.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import RHandler from '../../../../app/services/assets/handlers/r';
+import Constants from '../../../../app/constants/constants';
 
 jest.mock('fs');
 jest.mock('os');
@@ -30,7 +31,7 @@ describe('services', () => {
         const handler = new RHandler();
         expect(handler.includeFile('/User/test/Project/r')).toBeFalsy();
         expect(handler.includeFile('C:/test/Project/Thumbs.db')).toBeFalsy();
-        expect(handler.includeFile('.statwrap-project.json')).toBeFalsy();
+        expect(handler.includeFile(Constants.StatWrapFiles.PROJECT)).toBeFalsy();
       });
 
       it('should exclude where R extension exists but is not the last', () => {

--- a/test/services/assets/handlers/sas.spec.js
+++ b/test/services/assets/handlers/sas.spec.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import SASHandler from '../../../../app/services/assets/handlers/sas';
+import Constants from '../../../../app/constants/constants';
 
 jest.mock('fs');
 jest.mock('os');
@@ -30,7 +31,7 @@ describe('services', () => {
         const handler = new SASHandler();
         expect(handler.includeFile('/User/test/Project/sas')).toBeFalsy();
         expect(handler.includeFile('C:/test/Project/Thumbs.db')).toBeFalsy();
-        expect(handler.includeFile('.statwrap-project.json')).toBeFalsy();
+        expect(handler.includeFile(Constants.StatWrapFiles.PROJECT)).toBeFalsy();
       });
 
       it('should exclude where SAS extension exists but is not the last', () => {

--- a/test/services/assets/handlers/stata.spec.js
+++ b/test/services/assets/handlers/stata.spec.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import StataHandler from '../../../../app/services/assets/handlers/stata';
+import Constants from '../../../../app/constants/constants';
 
 jest.mock('fs');
 jest.mock('os');
@@ -30,7 +31,7 @@ describe('services', () => {
         const handler = new StataHandler();
         expect(handler.includeFile('/User/test/Project/stata')).toBeFalsy();
         expect(handler.includeFile('C:/test/Project/Thumbs.db')).toBeFalsy();
-        expect(handler.includeFile('.statwrap-project.json')).toBeFalsy();
+        expect(handler.includeFile(Constants.StatWrapFiles.PROJECT)).toBeFalsy();
       });
 
       it('should exclude where Stata extension exists but is not the last', () => {

--- a/test/services/checklist.spec.js
+++ b/test/services/checklist.spec.js
@@ -1,0 +1,104 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const process = require('process');
+
+import ChecklistService from '../../app/services/checklist';
+import Constants from '../../app/constants/constants';
+
+jest.mock('fs');
+jest.mock('os');
+
+const TEST_USER_HOME_PATH = process.platform === 'win32' ? 'C:\\Users\\test' : '/User/test';
+os.homedir.mockReturnValue(TEST_USER_HOME_PATH);
+const TEST_PROJECT_PATH = process.platform === 'win32' ? 'C:\\testProject' : '~/testProject';
+
+describe('services', () => {
+  describe('ChecklistService', () => {
+    const mockProjectPath = TEST_PROJECT_PATH;
+    const resolvedProjectPath = path.join(TEST_USER_HOME_PATH, 'testProject', Constants.StatWrapFiles.BASE_FOLDER, Constants.StatWrapFiles.CHECKLIST);
+    const checklistData = [{ id: 1, name: 'Dependency', statement: 'All the software dependencies for the project are documented.', answer: true }];
+
+    const checklistService = new ChecklistService();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('writeChecklist', () => {
+      it('should throw an error if projectPath is null or undefined', () => {
+        expect(() => checklistService.writeChecklist(null, checklistData)).toThrow('Invalid project path or checklist data');
+        expect(() => checklistService.writeChecklist(undefined, checklistData)).toThrow('Invalid project path or checklist data');
+      });
+
+      it('should throw an error if checklist data is null or undefined', () => {
+        expect(() => checklistService.writeChecklist(mockProjectPath, null)).toThrow('Invalid project path or checklist data');
+        expect(() => checklistService.writeChecklist(mockProjectPath, undefined)).toThrow('Invalid project path or checklist data');
+      });
+
+      it('should correctly resolve the project path and write checklist data to a file', () => {
+        fs.writeFileSync = jest.fn();
+
+        checklistService.writeChecklist(mockProjectPath, checklistData);
+
+        expect(fs.writeFileSync).toHaveBeenCalledWith(
+          resolvedProjectPath,
+          JSON.stringify(checklistData)
+        );
+      });
+
+      it('should handle errors thrown during file write', () => {
+        fs.writeFileSync = jest.fn(() => {
+          throw new Error('Write failed');
+        });
+
+        expect(() => checklistService.writeChecklist(mockProjectPath, checklistData)).toThrow('Write failed');
+      });
+    });
+
+    describe('loadChecklist', () => {
+      it('should return an error if projectPath is null or undefined', (done) => {
+        checklistService.loadChecklist(null, (err, result) => {
+          expect(err).toBe('The project path must be specified');
+          expect(result).toBeNull();
+          done();
+        });
+      });
+
+      it('should return an error if checklist file does not exist', (done) => {
+        fs.existsSync = jest.fn().mockReturnValue(false);
+
+        checklistService.loadChecklist(mockProjectPath, (err, result) => {
+          expect(err).toBe('Checklist file not found');
+          expect(result).toEqual([]);
+          done();
+        });
+      });
+
+      it('should correctly read and parse checklist data from the file', (done) => {
+        fs.existsSync = jest.fn().mockReturnValue(true);
+        fs.readFileSync = jest.fn().mockReturnValue(JSON.stringify(checklistData));
+
+        checklistService.loadChecklist(mockProjectPath, (err, result) => {
+          expect(err).toBeNull();
+          expect(result).toEqual(checklistData);
+          expect(fs.readFileSync).toHaveBeenCalledWith(resolvedProjectPath);
+          done();
+        });
+      });
+
+      it('should return an error if file read or parsing fails', (done) => {
+        fs.existsSync = jest.fn().mockReturnValue(true);
+        fs.readFileSync = jest.fn(() => {
+          throw new Error('Read failed');
+        });
+
+        checklistService.loadChecklist(mockProjectPath, (err, result) => {
+          expect(err).toBe('Error reading or parsing checklist file');
+          expect(result).toBeNull();
+          done();
+        });
+      });
+    });
+  });
+});

--- a/test/services/project.spec.js
+++ b/test/services/project.spec.js
@@ -56,7 +56,7 @@ describe('services', () => {
         const project = new ProjectService().loadProjectFile('~/Test/Path');
         expect(project).not.toBeNull();
         expect(fs.readFileSync).toHaveBeenCalledWith(
-          `${TEST_USER_HOME_PATH}Test/Path/${Constants.StatWrapFiles.BASE_FOLDER}/.statwrap-project.json`,
+          `${TEST_USER_HOME_PATH}Test/Path/${Constants.StatWrapFiles.BASE_FOLDER}/${Constants.StatWrapFiles.PROJECT}`,
         );
       });
       it.onWindows('should resolve the ~ home path', () => {
@@ -64,7 +64,7 @@ describe('services', () => {
         const project = new ProjectService().loadProjectFile('~\\Test\\Path');
         expect(project).not.toBeNull();
         expect(fs.readFileSync).toHaveBeenCalledWith(
-          `${TEST_USER_HOME_PATH}Test\\Path\\${Constants.StatWrapFiles.BASE_FOLDER}\\.statwrap-project.json`,
+          `${TEST_USER_HOME_PATH}Test\\Path\\${Constants.StatWrapFiles.BASE_FOLDER}\\${Constants.StatWrapFiles.PROJECT}`,
         );
       });
       it.onMac('should return the project details', () => {
@@ -72,7 +72,7 @@ describe('services', () => {
         const project = new ProjectService().loadProjectFile('/Test/Path');
         expect(project).not.toBeNull();
         expect(fs.readFileSync).toHaveBeenCalledWith(
-          `/Test/Path/${Constants.StatWrapFiles.BASE_FOLDER}/.statwrap-project.json`,
+          `/Test/Path/${Constants.StatWrapFiles.BASE_FOLDER}/${Constants.StatWrapFiles.PROJECT}`,
         );
       });
       it.onWindows('should return the project details', () => {
@@ -80,7 +80,7 @@ describe('services', () => {
         const project = new ProjectService().loadProjectFile('C:\\Test\\Path');
         expect(project).not.toBeNull();
         expect(fs.readFileSync).toHaveBeenCalledWith(
-          `C:\\Test\\Path\\${Constants.StatWrapFiles.BASE_FOLDER}\\.statwrap-project.json`,
+          `C:\\Test\\Path\\${Constants.StatWrapFiles.BASE_FOLDER}\\${Constants.StatWrapFiles.PROJECT}`,
         );
       });
       it('should throw an exception if the JSON is invalid', () => {
@@ -127,28 +127,28 @@ describe('services', () => {
       it.onMac('should resolve the ~ home path', () => {
         new ProjectService().saveProjectFile('~/Test/Path', { id: '1' });
         expect(fs.writeFileSync).toHaveBeenCalledWith(
-          `${TEST_USER_HOME_PATH}Test/Path/${Constants.StatWrapFiles.BASE_FOLDER}/.statwrap-project.json`,
+          `${TEST_USER_HOME_PATH}Test/Path/${Constants.StatWrapFiles.BASE_FOLDER}/${Constants.StatWrapFiles.PROJECT}`,
           '{"id":"1"}',
         );
       });
       it.onWindows('should resolve the ~ home path', () => {
         new ProjectService().saveProjectFile('~\\Test\\Path', { id: '1' });
         expect(fs.writeFileSync).toHaveBeenCalledWith(
-          `${TEST_USER_HOME_PATH}Test\\Path\\${Constants.StatWrapFiles.BASE_FOLDER}\\.statwrap-project.json`,
+          `${TEST_USER_HOME_PATH}Test\\Path\\${Constants.StatWrapFiles.BASE_FOLDER}\\${Constants.StatWrapFiles.PROJECT}`,
           '{"id":"1"}',
         );
       });
       it.onMac('should save the project details', () => {
         new ProjectService().saveProjectFile('/Test/Path', { id: '1' });
         expect(fs.writeFileSync).toHaveBeenCalledWith(
-          `/Test/Path/${Constants.StatWrapFiles.BASE_FOLDER}/.statwrap-project.json`,
+          `/Test/Path/${Constants.StatWrapFiles.BASE_FOLDER}/${Constants.StatWrapFiles.PROJECT}`,
           '{"id":"1"}',
         );
       });
       it.onWindows('should save the project details', () => {
         new ProjectService().saveProjectFile('C:\\Test\\Path', { id: '1' });
         expect(fs.writeFileSync).toHaveBeenCalledWith(
-          `C:\\Test\\Path\\${Constants.StatWrapFiles.BASE_FOLDER}\\.statwrap-project.json`,
+          `C:\\Test\\Path\\${Constants.StatWrapFiles.BASE_FOLDER}\\${Constants.StatWrapFiles.PROJECT}`,
           '{"id":"1"}',
         );
       });
@@ -166,7 +166,7 @@ describe('services', () => {
           { recursive: true },
         );
         expect(fs.writeFileSync).toHaveBeenCalledWith(
-          `/Test/Path/${Constants.StatWrapFiles.BASE_FOLDER}/.statwrap-project.json`,
+          `/Test/Path/${Constants.StatWrapFiles.BASE_FOLDER}/${Constants.StatWrapFiles.PROJECT}`,
           '{"id":"1"}',
         );
       });
@@ -184,7 +184,7 @@ describe('services', () => {
           { recursive: true },
         );
         expect(fs.writeFileSync).toHaveBeenCalledWith(
-          `C:\\Test\\Path\\${Constants.StatWrapFiles.BASE_FOLDER}\\.statwrap-project.json`,
+          `C:\\Test\\Path\\${Constants.StatWrapFiles.BASE_FOLDER}\\${Constants.StatWrapFiles.PROJECT}`,
           '{"id":"1"}',
         );
       });

--- a/test/utils/asset.spec.js
+++ b/test/utils/asset.spec.js
@@ -1,7 +1,7 @@
 import AssetUtil from '../../app/utils/asset';
 import Constants from '../../app/constants/constants';
 
-describe('services', () => {
+describe('utils', () => {
   describe('AssetUtil', () => {
     describe('getHandlerMetadata', () => {
       it('should return null when there is no metadata', () => {

--- a/test/utils/checklist.spec.js
+++ b/test/utils/checklist.spec.js
@@ -1,0 +1,113 @@
+import ChecklistUtil from "../../app/utils/checklist";
+import Constants from "../../app/constants/constants";
+
+describe('utils', () => {
+  describe('ChecklistUtil', () => {
+    describe('findAssetLanguagesAndDependencies', () => {
+      it('should return empty result when asset is null or undefined', () => {
+        expect(ChecklistUtil.findAssetLanguagesAndDependencies(null)).toEqual({
+          languages: [],
+          dependencies: [],
+        });
+        expect(ChecklistUtil.findAssetLanguagesAndDependencies(undefined)).toEqual({
+          languages: [],
+          dependencies: [],
+        });
+      });
+
+      it('should return correct languages and dependencies for valid code assets', () => {
+        const languages = {'R': ['r', 'rmd', 'rnw', 'snw'], 'Python': ['py', 'py3', 'pyi'], 'SAS': ['sas'], 'Stata': ['do', 'ado', 'mata'], 'HTML': ['htm', 'html']};
+        Object.keys(languages).forEach((lang) => {
+          languages[lang].forEach((ext) => {
+            expect(ChecklistUtil.findAssetLanguagesAndDependencies({
+              type: Constants.AssetType.FILE,
+              contentTypes: [Constants.AssetContentType.CODE],
+              uri: `path/to/file.${ext}`,
+            })).toEqual({
+              languages: [lang],
+              dependencies: [],
+            });
+          });
+        });
+      });
+
+      it('should return empty result for non-code assets (data, documentation)', () => {
+        expect(ChecklistUtil.findAssetLanguagesAndDependencies({
+          type: Constants.AssetType.FILE,
+          contentTypes: [Constants.AssetContentType.DATA],
+          uri: 'path/to/file.csv',
+        })).toEqual({
+          languages: [],
+          dependencies: [],
+        });
+      });
+
+      it('should return empty result for directory/folder type assets', () => {
+        expect(ChecklistUtil.findAssetLanguagesAndDependencies({
+          type: Constants.AssetType.DIRECTORY,
+          contentTypes: [Constants.AssetContentType.CODE],
+          uri: 'path/to/directory/',
+        })).toEqual({
+          languages: [],
+          dependencies: [],
+        });
+      });
+
+      it('should not identify malformed URIs', () => {
+        expect(ChecklistUtil.findAssetLanguagesAndDependencies({
+          type: Constants.AssetType.FILE,
+          contentTypes: [Constants.AssetContentType.CODE],
+          uri: 'path/to/malformed-uri.',
+        })).toEqual({
+          languages: [],
+          dependencies: [],
+        });
+      });
+
+      it('should ignore random/unknown extensions that are not in the content types', () => {
+        expect(ChecklistUtil.findAssetLanguagesAndDependencies({
+          type: Constants.AssetType.FILE,
+          contentTypes: [Constants.AssetContentType.CODE],
+          uri: 'path/to/file.cmd',
+        })).toEqual({
+          languages: [],
+          dependencies: [],
+        });
+      });
+
+      it('should handle nested assets and recurse properly', () => {
+        expect(ChecklistUtil.findAssetLanguagesAndDependencies({
+          type: Constants.AssetType.FOLDER,
+          contentTypes: [Constants.AssetContentType.CODE],
+          uri: 'path/to/folder',
+          children: [
+            {
+              type: Constants.AssetType.FILE,
+              contentTypes: [Constants.AssetContentType.CODE],
+              uri: 'path/to/folder/file1.py',
+            },
+            {
+              type: Constants.AssetType.FILE,
+              contentTypes: [Constants.AssetContentType.CODE],
+              uri: 'path/to/folder/file2.r',
+            }
+          ],
+        })).toEqual({
+          languages: ['Python', 'R'], // don't change the languages ordering in this array
+          dependencies: [],
+        });
+      });
+
+      it('should not crash when asset has no extension in its URI', () => {
+        expect(ChecklistUtil.findAssetLanguagesAndDependencies({
+          type: Constants.AssetType.FILE,
+          contentTypes: [Constants.AssetContentType.CODE],
+          uri: 'path/to/file',
+        })).toEqual({
+          languages: [],
+          dependencies: [],
+        });
+      });
+    });
+  });
+});

--- a/test/utils/general.spec.js
+++ b/test/utils/general.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable prettier/prettier */
 import GeneralUtil from '../../app/utils/general';
 
-describe('services', () => {
+describe('utils', () => {
   describe('GeneralUtil', () => {
     describe('formatDateTime', () => {
       it('returns an empty string for an empty date parameter', () => {

--- a/test/utils/note.spec.js
+++ b/test/utils/note.spec.js
@@ -1,6 +1,6 @@
 import AssetUtil from '../../app/utils/note';
 
-describe('services', () => {
+describe('utils', () => {
   describe('NoteUtil', () => {
     describe('createNote', () => {
       it('creates the note', () => {

--- a/test/utils/workflow.spec.js
+++ b/test/utils/workflow.spec.js
@@ -2,7 +2,7 @@
 import WorkflowUtil from '../../app/utils/workflow';
 import Constants from '../../app/constants/constants';
 
-describe('services', () => {
+describe('utils', () => {
   describe('WorkwlowUtil', () => {
     describe('getAllDependencies', () => {
       it('should handle empty/invalid inputs', () => {


### PR DESCRIPTION
## Summary
This PR refactors functions related to the checklist by moving them to the utility module and also adds unit tests for both the checklist service and utility. Minor changes have been made to other parts of the code, including the creation of the project file constant, and replacing `os.homedir` with `os.homedir()` in some places.

**Note**: Unit tests for the `convertImageToBase64` function in the general utils have not been implemented due to the need for generating mock base64 strings for dummy file paths, which are quite LONG. Though, if you have any suggestions to address this, please LMK.
### Reviewer
@lrasmus 