### PR TITLE
'Add Project to Favorites' Functionality fixed

### DIFF
--- a/app/components/Project/Project.js
+++ b/app/components/Project/Project.js
@@ -906,9 +906,12 @@ class Project extends Component<Props> {
         <TabContext value={this.state.selectedTab}>
           <div className={styles.header}>
             <div className={styles.titleContainer}>
-              <IconButton color="inherit">
-                {this.props.project && this.props.project.favorite ? <Star /> : <StarBorder />}
-              </IconButton>
+              <IconButton
+            color="inherit"
+            onClick={() => this.props.onFavoriteClick(this.props.project.id)}
+          >
+            {this.props.project && this.props.project.favorite ? <Star /> : <StarBorder />}
+          </IconButton>
               <div className={styles.title}>
                 {name}
                 {projectPath}

--- a/app/containers/ProjectPage/ProjectPage.js
+++ b/app/containers/ProjectPage/ProjectPage.js
@@ -311,9 +311,25 @@ class ProjectPage extends Component {
     });
   }
 
-  handleFavoriteClick(id) {
+  handleFavoriteClick = (id) => {
+    this.setState((prevState) => {
+      const updatedProjects = prevState.projects.map((project) =>
+        project.id === id ? { ...project, favorite: !project.favorite } : project
+      );
+  
+      const updatedSelectedProject =
+        prevState.selectedProject?.id === id
+          ? { ...prevState.selectedProject, favorite: !prevState.selectedProject.favorite }
+          : prevState.selectedProject;
+  
+      return {
+        projects: updatedProjects,
+        selectedProject: updatedSelectedProject,
+      };
+    });
+  
     ipcRenderer.send(Messages.TOGGLE_PROJECT_FAVORITE_REQUEST, id);
-  }
+  };
 
   handleAddProject() {
     this.setState({ addingProject: true });
@@ -428,6 +444,7 @@ class ProjectPage extends Component {
           />
           <Project
             project={this.state.selectedProject}
+            onFavoriteClick={this.handleFavoriteClick}
             logs={this.state.selectedProjectLogs}
             checklistResponse={this.state.selectedProjectChecklist}
             onUpdated={this.handleProjectUpdate}


### PR DESCRIPTION
Fixes #191 
Expected Behaviour: Users should be able to add or remove projects to favorites by clicking on the "Star" icon in the dashboard.
Fixed now