### PR TITLE
feat:implement live search with debounce

### DIFF
--- a/app/components/Search/Search.js
+++ b/app/components/Search/Search.js
@@ -324,6 +324,7 @@ const Search = (props) => {
   const handleSearchChange = (e) => {
     const value = e.target.value;
     setSearchTerm(value);
+
     if (searchTimeout) {
       clearTimeout(searchTimeout);
       setSearchTimeout(null);
@@ -341,6 +342,19 @@ const Search = (props) => {
     if (!value.trim()) {
       setFullSearchResults(EMPTY_SEARCH_RESULTS);
       setExpandedItems({});
+      return;
+    }
+
+    // Live search with debounce - trigger search after user stops typing
+    const minLength = SearchConfig.ui?.minSearchLength || 2;
+    const delay = SearchConfig.ui?.liveSearchDelay || 400;
+
+    if (value.trim().length >= minLength) {
+      const timeout = setTimeout(() => {
+        performSearch(value);
+        setShowSuggestions(false);
+      }, delay);
+      setSearchTimeout(timeout);
     }
   };
 
@@ -557,7 +571,7 @@ const Search = (props) => {
                       inputRef={searchInputRef}
                       fullWidth
                       variant="outlined"
-                      placeholder="Search for projects, files, people, notes... (Press Enter or click Search)"
+                      placeholder="Search for projects, files, people, notes..."
                       disabled={isInitializing}
                       onKeyUp={handleSearchKeyUp}
                       onChange={handleSearchChange}

--- a/app/constants/search-config.js
+++ b/app/constants/search-config.js
@@ -191,6 +191,8 @@ module.exports = {
     maxSuggestions: 8,
     showRelevanceScores: process.env.NODE_ENV === 'development',
     enableKeyboardShortcuts: true,
+    liveSearchDelay: 400,  // Delay in ms before triggering live search after user stops typing
+    minSearchLength: 2,    // Minimum characters required before triggering live search
   },
 
   // Performance settings


### PR DESCRIPTION
Summary
Implements live search with debouncing as requested in #289. Users no longer need to press Enter to execute a search - results appear automatically after typing stops.

## Changes
- Added `liveSearchDelay` (400ms) and `minSearchLength` (2) config options to `search-config.js`
- Modified `handleSearchChange` in `Search.js` to trigger debounced search using `setTimeout`
- Updated search placeholder text to remove "(Press Enter or click Search)" instruction

## How It Works
- When user types, any pending search timeout is cleared
- A new timeout is set for 400ms
- If user stops typing for 400ms, search executes automatically
- Minimum 2 characters required before search triggers
- Enter key and Search button still work as manual triggers

## Configuration
Both values are configurable in `search-config.js`:
```js
liveSearchDelay: 400,  // Delay in ms
minSearchLength: 2,    // Minimum characters
