### PR TITLE
Feature: Auto-select default project on app load

### DIFF
--- a/app/containers/ProjectPage/ProjectPage.js
+++ b/app/containers/ProjectPage/ProjectPage.js
@@ -183,7 +183,31 @@ class ProjectPage extends Component {
   }
 
   handleLoadProjectListResponse(sender, response) {
+    // Auto-select default project if no project is currently selected
+    let defaultProject = null;
+    if (!this.state.selectedProject && response.projects && response.projects.length > 0) {
+      // Priority 1: Pinned/favorited projects
+      const pinnedProjects = response.projects.filter((p) => p.favorite);
+      if (pinnedProjects.length > 0) {
+        defaultProject = pinnedProjects[0];
+      } else {
+        // Priority 2: Active projects (not marked as 'past')
+        const activeProjects = response.projects.filter((p) => p.status !== 'past');
+        if (activeProjects.length > 0) {
+          defaultProject = activeProjects[0];
+        } else {
+          // Priority 3: Any project
+          defaultProject = response.projects[0];
+        }
+      }
+    }
+
     this.setState({ ...response, loaded: true });
+
+    // Select the default project after state is updated
+    if (defaultProject) {
+      this.handleSelectProjectListItem(defaultProject);
+    }
   }
 
   handleLoadConfigurationResponse(sender, response) {


### PR DESCRIPTION
## Description

Fixes #288 - Auto-select default project on app load

## Problem

When the app launches, users see a "Welcome to StatWrap" placeholder page with no project selected. This requires users to manually select a project every time they open the app, which creates extra friction in the workflow.

## Solution

Automatically select a default project when the project list is loaded, using intelligent priority ordering:

1. **Pinned/Favorited projects** - User's most important projects take priority
2. **Active projects** - Projects not marked as 'past' are preferred
3. **Any available project** - Fallback to ensure something is always selected