### PR TITLE
Add feature to select sub-folder of project for dependency view

### DIFF
--- a/app/components/Workflow/DependencyGraph/DependencyGraphEChart.js
+++ b/app/components/Workflow/DependencyGraph/DependencyGraphEChart.js
@@ -72,7 +72,7 @@ function DependencyGraphEChart(props) {
     if (assets) {
       const filteredAssets = WorkflowUtil.filterArchivedAssets(assets);
       setFilter(updatedFilter);
-      setGraphData(WorkflowUtil.getAllDependenciesAsEChartGraph(filteredAssets, filter));
+      setGraphData(WorkflowUtil.getAllDependenciesAsEChartGraph(filteredAssets, updatedFilter));
     } else {
       setGraphData(null);
     }

--- a/app/components/Workflow/Workflow.css
+++ b/app/components/Workflow/Workflow.css
@@ -8,6 +8,18 @@
   align-items: center;
 }
 
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.directorySelect {
+  min-width: 200px !important;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
 .buttonsWrapper {
   margin-left: auto;
   display: flex;

--- a/app/components/Workflow/Workflow.js
+++ b/app/components/Workflow/Workflow.js
@@ -1,13 +1,59 @@
-import { ToggleButtonGroup, ToggleButton } from '@mui/material';
-import React, { useState } from 'react';
+import { ToggleButtonGroup, ToggleButton, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import AssetUtil from '../../utils/asset';
+import WorkflowUtil from '../../utils/workflow';
+import ProjectUtil from '../../utils/project';
+import Constants from '../../constants/constants';
 import DependencyGraph from './DependencyGraph/DependencyGraphEChart';
 import DependencyTree from './DependencyTree/DependencyTreeEChart';
 import styles from './Workflow.css';
 
 function Workflow(props) {
+  const { project } = props;
   const [diagram, setDiagram] = useState('graph');
   const [zoomLevel, setZoomLevel] = useState(1);
+  const [selectedAssetUri, setSelectedAssetUri] = useState('');
+
+  // Get a flat list of all directories in the project
+  const getAllDirectories = (asset, rootPath) => {
+    let dirs = [];
+    if (!asset) {
+      return dirs;
+    }
+
+    // specific check to exclude the .statwrap folder and other hidden folders
+    if (!AssetUtil.includeAsset(asset.uri)) {
+      return dirs;
+    }
+
+    if (asset.type === Constants.AssetType.DIRECTORY || asset.type === Constants.AssetType.FOLDER) {
+      let displayName = asset.uri;
+      if (rootPath) {
+        const relativeName = AssetUtil.absoluteToRelativePath(rootPath, asset);
+        displayName = relativeName === '' || relativeName === null ? 'Project Root' : relativeName;
+      }
+      dirs.push({ uri: asset.uri, name: displayName });
+    }
+
+    if (asset.children) {
+      asset.children.forEach((child) => {
+        dirs = dirs.concat(getAllDirectories(child, rootPath));
+      });
+    }
+    return dirs;
+  };
+
+  const directories = React.useMemo(() => {
+    return project && project.assets ? getAllDirectories(project.assets, project.assets.uri) : [];
+  }, [project]);
+
+  // Whenever the project changes, we want to reset our selection to the root
+  useEffect(() => {
+    if (project && project.assets) {
+      setSelectedAssetUri(project.assets.uri);
+    }
+  }, [project]);
 
   const handleDiagram = (event, newDiagram) => {
     setDiagram(newDiagram);
@@ -21,28 +67,51 @@ function Workflow(props) {
     setZoomLevel((prevZoom) => prevZoom / 1.2);
   };
 
-  const { project } = props;
-  let graph = <DependencyGraph assets={project.assets} zoomLevel={zoomLevel} />;
+  const handleAssetSelectChange = (event) => {
+    setSelectedAssetUri(event.target.value);
+  };
+
+  const targetAsset = WorkflowUtil.findAssetByUri(project.assets, selectedAssetUri) || project.assets;
+
+  let graph = <DependencyGraph assets={targetAsset} zoomLevel={zoomLevel} />;
   if (diagram === 'tree') {
-    graph = <DependencyTree assets={project.assets} />;
+    graph = <DependencyTree assets={targetAsset} />;
   }
 
   return (
     <div className={styles.container}>
       <div className={styles.header}>
-        <ToggleButtonGroup
-          value={diagram}
-          exclusive
-          onChange={handleDiagram}
-          aria-label="select workflow diagram"
-        >
-          <ToggleButton value="graph" aria-label="dependency graph">
-            Dependency Graph
-          </ToggleButton>
-          <ToggleButton value="tree" aria-label="dependency tree">
-            Tree
-          </ToggleButton>
-        </ToggleButtonGroup>
+        <div className={styles.controls}>
+          <ToggleButtonGroup
+            value={diagram}
+            exclusive
+            onChange={handleDiagram}
+            aria-label="select workflow diagram"
+          >
+            <ToggleButton value="graph" aria-label="dependency graph">
+              Dependency Graph
+            </ToggleButton>
+            <ToggleButton value="tree" aria-label="dependency tree">
+              Tree
+            </ToggleButton>
+          </ToggleButtonGroup>
+          <FormControl margin="dense" className={styles.directorySelect}>
+            <InputLabel id="asset-select-label">View Directory</InputLabel>
+            <Select
+              labelId="asset-select-label"
+              id="asset-select"
+              value={selectedAssetUri}
+              label="View Directory"
+              onChange={handleAssetSelectChange}
+            >
+              {directories.map((dir) => (
+                <MenuItem key={dir.uri} value={dir.uri}>
+                  {dir.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </div>
         <span className={styles.projectPath}>
           Paths shown relative to project home:
           <br />


### PR DESCRIPTION
### Description
This PR implements the ability to filter the Dependency Graph and Tree views by selecting a specific sub-directory within the project.

### Fixes 
Fixes #141 

### Changes

1. app/components/Workflow/Workflow.js :
   - Added selectedAssetUri state to track the active directory.
   - Implemented getallDirectories.
   - Added View Directory dropdown.
   - Updated the render logic to pass only the filtered sub-tree to child components.
   - Also added stying to the new dropdown in the Workflow.css
 
### Screnshots : 

Here I created a TestProject just to check , here I am seeing all my sub-directories in the dropdown list.

<img width="1440" height="900" alt="1" src="https://github.com/user-attachments/assets/6d4f2a04-0ed7-4061-a6bd-46eedaed25c6" />


I selected one of them: 
<img width="1440" height="900" alt="2" src="https://github.com/user-attachments/assets/4b6e1827-4470-4262-ae85-6ff03f5f2f23" />

I selected other:

<img width="1440" height="900" alt="3" src="https://github.com/user-attachments/assets/0fdadd21-5ccf-4410-a17d-caec2faea99d" />

