### PR TITLE
Fix three dots menu option making clickable

### DIFF
--- a/app/containers/ProjectPage/ProjectPage.js
+++ b/app/containers/ProjectPage/ProjectPage.js
@@ -643,6 +643,9 @@ class ProjectPage extends Component {
           anchorElement={
             this.state.projectListMenuAnchor ? this.state.projectListMenuAnchor.element : null
           }
+          project={
+    this.state.projectListMenuAnchor ? this.state.projectListMenuAnchor.project : null
+  }
           onClose={this.handleCloseProjectListMenu}
           onMenuClick={this.handleClickProjectListMenu}
         />


### PR DESCRIPTION
### Description 
Currently three dots(menu) is  clickable but return nothing  due to the missing project data.

### Changes 
- Passed the project object to the ProjectListEntryMenu component.

