### PR TITLE
Add recommendations for persons

### DIFF
--- a/app/components/People/People.js
+++ b/app/components/People/People.js
@@ -7,6 +7,7 @@ import CreateUpdatePersonDialog from '../../containers/CreateUpdatePersonDialog/
 import PeopleCardList from './PeopleCardList/PeopleCardList';
 import PeopleTable from './PeopleTable/PeopleTable';
 import SettingsContext from '../../contexts/Settings';
+import GeneralUtil from '../../utils/general';
 import styles from './People.css';
 
 function people(props) {
@@ -32,6 +33,11 @@ function people(props) {
   const [editPersonRoles, setEditPersonRoles] = useState(null);
 
   const settings = useContext(SettingsContext);
+
+  // Extract recommended people from project assets
+  const recommendations = project && project.assets 
+    ? GeneralUtil.getRecommendedPeopleFromAssets(project.assets)
+    : [];
 
   // UI state flag to let us know when we're in the process of adding/editing a person
   const [editing, setEditing] = useState(false);
@@ -141,6 +147,7 @@ function people(props) {
         key={dialogKey}
         mode={mode}
         directory={settings.directory}
+        recommendations={recommendations}
         user={settings.user}
         project={project}
         id={editPersonId}


### PR DESCRIPTION
Fixes #303
This PR introduces support for identifying potential people from project assets and making them available in the People tab for easy addition by the user.

Initially, this feature is limited to a small set of supported file types:
- RMarkdown
- Quarto
For these documents, the system inspects metadata fields (specifically the defined author field) to extract candidate people.