### PR TITLE
Preserve the asset expansion state when in the same project view

### DIFF
--- a/app/components/Project/Project.js
+++ b/app/components/Project/Project.js
@@ -917,7 +917,7 @@ class Project extends Component<Props> {
           <TabPanel value="about" style={{ padding: '10px' }}>
             {about}
           </TabPanel>
-          <TabPanel value="assets" style={{ padding: '10px' }}>
+          <TabPanel value="assets" keepMounted style={{ padding: '10px' }}>
             {assets}
           </TabPanel>
           <TabPanel value="workflows" style={{ padding: '10px' }}>


### PR DESCRIPTION
### Description : 
The issue is that the expanded asset folder does not  remain expand when you move to other options  and comeback when in the same project.This PR fixes this issue.

### Fixes 
Fixes #46 

### Changes : 

- app/components/Project/Project.js : Added the keepMounted prop 

### Screen Recording : 

 

https://github.com/user-attachments/assets/61187204-87c6-412a-85c0-430a5b2ce1ab



