### PR TITLE
Fix inconsistent naming for project pinning

### DIFF
--- a/app/components/Projects/ProjectListEntryMenu/ProjectListEntryMenu.js
+++ b/app/components/Projects/ProjectListEntryMenu/ProjectListEntryMenu.js
@@ -5,7 +5,7 @@ import Messages from '../../../constants/messages';
 import Constants from '../../../constants/constants';
 
 function projectListEntryMenu(props) {
-  if (!props.project){
+  if (!props.project) {
     return null;
   }
   const isPinned = props.project.favorite;
@@ -25,9 +25,9 @@ function projectListEntryMenu(props) {
           props.onMenuClick(Messages.TOGGLE_PROJECT_FAVORITE_REQUEST, props.project.id)
         }
       >
-      {isPinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
+        {isPinned ? 'Unpin Project' : 'Pin Project'}
       </MenuItem>
-      
+
       {/* Status toggle option - only for non-pinned projects */}
       {!isPinned && (
         <>
@@ -41,20 +41,18 @@ function projectListEntryMenu(props) {
           </MenuItem>
         </>
       )}
-      
+
       <Divider />
 
       <MenuItem
-        onClick={() =>
-          props.onMenuClick(Messages.SHOW_ITEM_IN_FOLDER, props.project.path)
-        }
+        onClick={() => props.onMenuClick(Messages.SHOW_ITEM_IN_FOLDER, props.project.path)}
         disabled={props.project.loadError}
       >
         Show in Folder
       </MenuItem>
-      
+
       <Divider />
-      
+
       {/* Remove option */}
       <MenuItem
         onClick={() =>


### PR DESCRIPTION
## Description
This PR resolves the inconsistency in naming related to pinning projects. The text "Pin to Favorites" has been renamed to "Pin Project" and "Unpin from Favorites" has been renamed to "Unpin Project" so that it aligns with the existing "Pinned Projects" section. These changes make the terminology consistent across the UI.

## Fixes
Fixes #283

## Changes
- "Pin to Favorites" renamed to "Pin Project"
- "Unpin from Favorites" renamed to "Unpin Project"

## Screenshots
<img width="522" height="129" alt="image" src="https://github.com/user-attachments/assets/df7cc18d-c369-42c0-87b6-aa62d23e0ee8" />
<img width="535" height="165" alt="image" src="https://github.com/user-attachments/assets/2316a7e1-4149-462a-b72a-432fa042d95c" />
