### PR TITLE
feat: implement configurable reproducibility checklist options (Issue…

### DIFF
--- a/app/components/ReproChecklist/ChecklistSettings/ChecklistSettings.css
+++ b/app/components/ReproChecklist/ChecklistSettings/ChecklistSettings.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 0;
+}

--- a/app/components/ReproChecklist/ChecklistSettings/ChecklistSettings.js
+++ b/app/components/ReproChecklist/ChecklistSettings/ChecklistSettings.js
@@ -1,0 +1,221 @@
+import React, { useState, useContext } from 'react';
+import { ipcRenderer } from 'electron';
+import {
+  TextField,
+  Paper,
+  Typography,
+  Box,
+  IconButton,
+  Collapse,
+  Button,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemSecondaryAction,
+  Divider,
+} from '@mui/material';
+import {
+  ExpandMore,
+  ExpandLess,
+  SettingsOutlined,
+  AddOutlined,
+  DeleteOutlined,
+  EditOutlined,
+  SaveOutlined,
+  ClearOutlined,
+} from '@mui/icons-material';
+import { v4 as uuid } from 'uuid';
+import SettingsContext from '../../../contexts/Settings';
+import Messages from '../../../constants/messages';
+import styles from './ChecklistSettings.css';
+
+const ChecklistSettings = () => {
+  const { checklistSettings } = useContext(SettingsContext);
+  const [showConfig, setShowConfig] = useState(true);
+  const [isEditing, setIsEditing] = useState(null); // ID of the item being edited
+  const [newItem, setNewItem] = useState({ name: '', statement: '' });
+  const [editItem, setEditItem] = useState({ name: '', statement: '' });
+
+  const customItems = checklistSettings ? checklistSettings.customItems : [];
+
+  const handleSaveSettings = (updatedItems) => {
+    const updatedSettings = {
+      ...checklistSettings,
+      customItems: updatedItems,
+    };
+    ipcRenderer.send(Messages.CHECKLIST_UPDATE_SETTINGS_REQUEST, updatedSettings);
+  };
+
+  const handleAddItem = () => {
+    if (newItem.name.trim() === '' || newItem.statement.trim() === '') {
+      return;
+    }
+    const updatedItems = [
+      ...customItems,
+      { id: uuid(), name: newItem.name.trim(), statement: newItem.statement.trim() },
+    ];
+    handleSaveSettings(updatedItems);
+    setNewItem({ name: '', statement: '' });
+  };
+
+  const handleDeleteItem = (id) => {
+    const updatedItems = customItems.filter((item) => item.id !== id);
+    handleSaveSettings(updatedItems);
+  };
+
+  const handleStartEdit = (item) => {
+    setIsEditing(item.id);
+    setEditItem({ name: item.name, statement: item.statement });
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditing(null);
+    setEditItem({ name: '', statement: '' });
+  };
+
+  const handleSaveEdit = (id) => {
+    if (editItem.name.trim() === '' || editItem.statement.trim() === '') {
+      return;
+    }
+    const updatedItems = customItems.map((item) =>
+      item.id === id ? { ...item, name: editItem.name.trim(), statement: editItem.statement.trim() } : item
+    );
+    handleSaveSettings(updatedItems);
+    setIsEditing(null);
+    setEditItem({ name: '', statement: '' });
+  };
+
+  return (
+    <div className={styles.container}>
+      <Box mb={2}>
+        <Paper variant="outlined" sx={{ backgroundColor: 'background.default' }}>
+          <Box
+            sx={{
+              p: 2,
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+            onClick={() => setShowConfig(!showConfig)}
+          >
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <SettingsOutlined />
+              Reproducibility Checklist Configuration
+            </Typography>
+            <IconButton size="small">
+              {showConfig ? <ExpandLess /> : <ExpandMore />}
+            </IconButton>
+          </Box>
+
+          <Collapse in={showConfig}>
+            <Box sx={{ px: 2, pb: 2 }}>
+              <Typography variant="body2" color="textSecondary" gutterBottom>
+                Configure additional global questions for the project reproducibility checklist.
+                These questions will appear in all projects.
+              </Typography>
+
+              <List>
+                {customItems.map((item) => (
+                  <React.Fragment key={item.id}>
+                    <ListItem>
+                      {isEditing === item.id ? (
+                        <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 1 }}>
+                          <TextField
+                            fullWidth
+                            size="small"
+                            label="Item Name"
+                            value={editItem.name}
+                            onChange={(e) => setEditItem({ ...editItem, name: e.target.value })}
+                          />
+                          <TextField
+                            fullWidth
+                            size="small"
+                            label="Checklist Statement"
+                            multiline
+                            rows={2}
+                            value={editItem.statement}
+                            onChange={(e) => setEditItem({ ...editItem, statement: e.target.value })}
+                          />
+                          <Box display="flex" gap={1}>
+                            <Button
+                              size="small"
+                              variant="contained"
+                              startIcon={<SaveOutlined />}
+                              onClick={() => handleSaveEdit(item.id)}
+                            >
+                              Save
+                            </Button>
+                            <Button
+                              size="small"
+                              variant="outlined"
+                              startIcon={<ClearOutlined />}
+                              onClick={handleCancelEdit}
+                            >
+                              Cancel
+                            </Button>
+                          </Box>
+                        </Box>
+                      ) : (
+                        <>
+                          <ListItemText
+                            primary={item.name}
+                            secondary={item.statement}
+                          />
+                          <ListItemSecondaryAction>
+                            <IconButton edge="end" aria-label="edit" onClick={() => handleStartEdit(item)}>
+                              <EditOutlined />
+                            </IconButton>
+                            <IconButton edge="end" aria-label="delete" onClick={() => handleDeleteItem(item.id)}>
+                              <DeleteOutlined />
+                            </IconButton>
+                          </ListItemSecondaryAction>
+                        </>
+                      )}
+                    </ListItem>
+                    <Divider variant="inset" component="li" />
+                  </React.Fragment>
+                ))}
+              </List>
+
+              <Box sx={{ mt: 3, p: 2, border: '1px dashed #ccc', borderRadius: 1 }}>
+                <Typography variant="subtitle2" gutterBottom>
+                  Add New Checklist Item
+                </Typography>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                  <TextField
+                    fullWidth
+                    size="small"
+                    label="Item Name (e.g., Funding)"
+                    value={newItem.name}
+                    onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
+                  />
+                  <TextField
+                    fullWidth
+                    size="small"
+                    label="Checklist Statement (e.g., Funding sources are disclosed)"
+                    multiline
+                    rows={2}
+                    value={newItem.statement}
+                    onChange={(e) => setNewItem({ ...newItem, statement: e.target.value })}
+                  />
+                  <Button
+                    variant="contained"
+                    startIcon={<AddOutlined />}
+                    onClick={handleAddItem}
+                    disabled={newItem.name.trim() === '' || newItem.statement.trim() === ''}
+                    sx={{ alignSelf: 'flex-start' }}
+                  >
+                    Add Item
+                  </Button>
+                </Box>
+              </Box>
+            </Box>
+          </Collapse>
+        </Paper>
+      </Box>
+    </div>
+  );
+};
+
+export default ChecklistSettings;

--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -116,6 +116,10 @@ module.exports = {
 
   MAX_GRAPH_LABEL_LENGTH: 31,
 
+  DEFAULT_CHECKLIST_SETTINGS: {
+    customItems: []
+  },
+
   CHECKLIST: [
     ['Dependency', 'Software dependencies for the project are documented.'],
     ['Data', 'Data file(s) used in the project are documented.'],

--- a/app/constants/messages.js
+++ b/app/constants/messages.js
@@ -82,4 +82,7 @@ module.exports = {
   GET_APP_DATA_PATH: 'statwrap-get-app-data-path',
   SHOW_ITEM_IN_FOLDER: 'statwrap-show-item-in-folder',
   OPEN_FILE_WITH_DEFAULT: 'statwrap-open-file-with-default',
+
+  CHECKLIST_UPDATE_SETTINGS_REQUEST: 'statwrap-checklist-update-settings-request',
+  CHECKLIST_UPDATE_SETTINGS_RESPONSE: 'statwrap-checklist-update-settings-response',
 };

--- a/app/containers/ConfigurationPage/ConfigurationPage.js
+++ b/app/containers/ConfigurationPage/ConfigurationPage.js
@@ -2,6 +2,7 @@ import React, { Component, useContext } from 'react';
 import { ipcRenderer } from 'electron';
 import Messages from '../../constants/messages';
 import SearchSettings from '../../components/Search/SearchSettings/SearchSettings';
+import ChecklistSettings from '../../components/ReproChecklist/ChecklistSettings/ChecklistSettings';
 import styles from './ConfigurationPage.css';
 
 class ConfigurationPage extends Component {
@@ -40,6 +41,7 @@ class ConfigurationPage extends Component {
       <div className={styles.container} data-tid="container">
         <h1>Configuration</h1>
         <SearchSettings projects={this.state.loaded ? this.state.projects : null} />
+        <ChecklistSettings />
       </div>
     );
   }

--- a/app/containers/ProjectPage/ProjectPage.js
+++ b/app/containers/ProjectPage/ProjectPage.js
@@ -77,6 +77,7 @@ class ProjectPage extends Component {
     this.handleAddProject = this.handleAddProject.bind(this);
     this.handleCloseAddProject = this.handleCloseAddProject.bind(this);
     this.handleLoadConfigurationResponse = this.handleLoadConfigurationResponse.bind(this);
+    this.handleLoadUserInfoResponse = this.handleLoadUserInfoResponse.bind(this);
     this.handleProjectListEntryMenu = this.handleProjectListEntryMenu.bind(this);
     this.handleCloseProjectListMenu = this.handleCloseProjectListMenu.bind(this);
     this.handleClickProjectListMenu = this.handleClickProjectListMenu.bind(this);
@@ -101,6 +102,9 @@ class ProjectPage extends Component {
   componentDidMount() {
     ipcRenderer.send(Messages.LOAD_PROJECT_LIST_REQUEST);
     ipcRenderer.on(Messages.LOAD_PROJECT_LIST_RESPONSE, this.handleLoadProjectListResponse);
+
+    ipcRenderer.send(Messages.LOAD_USER_INFO_REQUEST);
+    ipcRenderer.on(Messages.LOAD_USER_INFO_RESPONSE, this.handleLoadUserInfoResponse);
 
     ipcRenderer.send(Messages.LOAD_CONFIGURATION_REQUEST);
     ipcRenderer.on(Messages.LOAD_CONFIGURATION_RESPONSE, this.handleLoadConfigurationResponse);
@@ -152,6 +156,7 @@ class ProjectPage extends Component {
       Messages.LOAD_CONFIGURATION_RESPONSE,
       this.handleLoadConfigurationResponse,
     );
+    ipcRenderer.removeListener(Messages.LOAD_USER_INFO_RESPONSE, this.handleLoadUserInfoResponse);
     ipcRenderer.removeListener(
       Messages.TOGGLE_PROJECT_FAVORITE_RESPONSE,
       this.refreshProjectsHandler,
@@ -267,6 +272,12 @@ class ProjectPage extends Component {
     });
   }
 
+  handleLoadUserInfoResponse(sender, response) {
+    this.setState({
+      checklistSettings: response.settings ? response.settings.checklistSettings : null,
+    });
+  }
+
   handleRefreshProjectLog() {
     ipcRenderer.send(Messages.LOAD_PROJECT_LOG_REQUEST, this.state.selectedProject);
   }
@@ -348,16 +359,44 @@ class ProjectPage extends Component {
       return;
     }
 
+    const customItems = this.state.checklistSettings
+      ? this.state.checklistSettings.customItems
+      : [];
+
     // Initialize the checklist file if it doesn't exist, for all the already existing projects
-    const projectChecklist = ChecklistUtil.initializeChecklist();
-    if (response.checklist && response.checklist.length === 0) {
+    let projectChecklist = response.checklist;
+    let updated = false;
+    if (!projectChecklist || projectChecklist.length === 0) {
+      projectChecklist = ChecklistUtil.initializeChecklist(customItems);
+      updated = true;
+    } else {
+      // Check if there are any custom items that aren't in the project checklist yet.
+      // We match by ID for custom items.
+      customItems.forEach((customItem) => {
+        if (!projectChecklist.find((item) => item.id === customItem.id)) {
+          projectChecklist.push({
+            id: customItem.id,
+            name: customItem.name,
+            statement: customItem.statement,
+            answer: false,
+            scanResult: {},
+            notes: [],
+            assets: [],
+            subChecklist: [],
+          });
+          updated = true;
+        }
+      });
+    }
+
+    if (updated) {
       // response only returns project id, we need to find the project path
       const project = this.state.projects.find((p) => p.id === response.projectId);
       ipcRenderer.send(Messages.WRITE_PROJECT_CHECKLIST_REQUEST, project.path, projectChecklist);
     }
 
     if (this.state.selectedProject && response.projectId === this.state.selectedProject.id) {
-      this.setState({ selectedProjectChecklist: response });
+      this.setState({ selectedProjectChecklist: { ...response, checklist: projectChecklist } });
     }
   }
 
@@ -374,6 +413,8 @@ class ProjectPage extends Component {
         selectedProjectLogs: null,
         selectedProjectChecklist: null,
         assetDynamicDetails: null,
+        checklistSettings: null,
+        projectScanStatus: null,
       });
       if (this.props.onSelectProject) {
         this.props.onSelectProject(null);

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -1163,6 +1163,34 @@ ipcMain.on(Messages.SEARCH_UPDATE_SETTINGS_REQUEST, async (event, searchSettings
   event.sender.send(Messages.SEARCH_UPDATE_SETTINGS_RESPONSE, response);
 });
 
+ipcMain.on(Messages.CHECKLIST_UPDATE_SETTINGS_REQUEST, async (event, checklistSettings) => {
+  const response = {
+    checklistSettings: checklistSettings,
+    error: false,
+    errorMessage: '',
+  };
+
+  if (!checklistSettings) {
+    response.error = true;
+    response.errorMessage = 'No checklist settings were provided';
+    event.sender.send(Messages.CHECKLIST_UPDATE_SETTINGS_RESPONSE, response);
+    return;
+  }
+
+  try {
+    const service = new UserService();
+    const userSettingsPath = path.join(app.getPath('userData'), DefaultSettingsFile);
+    const settings = service.loadUserSettingsFromFile(userSettingsPath);
+    settings.checklistSettings = checklistSettings;
+    service.saveUserSettingsToFile(settings, userSettingsPath);
+  } catch (e) {
+    response.error = true;
+    response.errorMessage = e.message;
+    console.log('Error updating checklist settings: ', e);
+  }
+  event.sender.send(Messages.CHECKLIST_UPDATE_SETTINGS_RESPONSE, response);
+});
+
 ipcMain.on(Messages.SEARCH_REQUEST, async (event, query, searchOptions) => {
   const response = {
     results: null,

--- a/app/services/user.js
+++ b/app/services/user.js
@@ -7,7 +7,8 @@ const DefaultSettingsFile = '.user-settings.json';
 
 // v1 - Original
 // v2 - Added searchSettings { maxIndexableFileSize }
-const SettingsFileFormatVersion = '2';
+// v3 - Added checklistSettings { customItems }
+const SettingsFileFormatVersion = '3';
 
 // Artificially set limit to how many people will be stored in the user's directory.  This
 // limit is imposed because the directory will act more like a 'most recently used' list than
@@ -44,6 +45,9 @@ export default class UserService {
       directory: [],
       searchSettings: {
         maxIndexableFileSize: DefaultMaxIndexableFileSize
+      },
+      checklistSettings: {
+        customItems: []
       }
     };
     try {
@@ -55,12 +59,21 @@ export default class UserService {
     const data = fs.readFileSync(filePath);
     settings = JSON.parse(data.toString());
 
-    if (settings.formatVersion == '1') {
-      // Upgrade to v2
+    if (settings.formatVersion == '1' || settings.formatVersion == '2') {
+      if (settings.formatVersion == '1') {
+        // Upgrade to v2
+        settings.searchSettings = {
+          maxIndexableFileSize: DefaultMaxIndexableFileSize
+        };
+      }
+
+      // Upgrade to v3
       settings.formatVersion = SettingsFileFormatVersion;
-      settings.searchSettings = {
-        maxIndexableFileSize: DefaultMaxIndexableFileSize
-      };
+      if (!settings.checklistSettings) {
+        settings.checklistSettings = {
+          customItems: []
+        };
+      }
     }
 
     return settings;

--- a/app/utils/checklist.js
+++ b/app/utils/checklist.js
@@ -10,7 +10,7 @@ export default class ChecklistUtil {
    * This function initializes the checklist with the statements and seeds other properties
    * @returns {object} The initialized checklist
    */
-  static initializeChecklist() {
+  static initializeChecklist(customItems = []) {
     const checklist = [];
     Constants.CHECKLIST.forEach((statement, index) => {
       checklist.push({
@@ -24,6 +24,22 @@ export default class ChecklistUtil {
         subChecklist: [],
       });
     });
+
+    if (customItems && customItems.length > 0) {
+      customItems.forEach((item) => {
+        checklist.push({
+          id: item.id,
+          name: item.name,
+          statement: item.statement,
+          answer: false,
+          scanResult: {},
+          notes: [],
+          assets: [],
+          subChecklist: [],
+        });
+      });
+    }
+
     return checklist;
   }
 

--- a/test/services/user.spec.js
+++ b/test/services/user.spec.js
@@ -45,6 +45,25 @@ const settingsString = `{
   }
 }`;
 
+// v3 default version
+const V3SettingsString = `{
+  "formatVersion": "3",
+  "directory": [
+    {
+      "name" : "Test User"
+    },
+    {
+      "name" : "Other User"
+    }
+  ],
+  "searchSettings": {
+    "maxIndexableFileSize": 102400
+  },
+  "checklistSettings": {
+    "customItems": []
+  }
+}`;
+
 const settingsObject = { formatVersion: '1', directory: [] };
 
 const invalidSettingsString = `{
@@ -75,17 +94,19 @@ describe('services', () => {
       it('should return the user settings from a specified file', () => {
         fs.readFileSync.mockReturnValue(settingsString);
         const settings = new UserService().loadUserSettingsFromFile('test-user-settings.json');
-        expect(settings.formatVersion).toBe('2');
+        expect(settings.formatVersion).toBe('3');
         expect(settings.directory.length).toBe(2);
         expect(settings.searchSettings.maxIndexableFileSize).toBe(102400);
+        expect(settings.checklistSettings.customItems.length).toBe(0);
         expect(fs.readFileSync).toHaveBeenCalledWith('test-user-settings.json');
       });
       it('should return the user settings from a default file', () => {
         fs.readFileSync.mockReturnValue(settingsString);
         const settings = new UserService().loadUserSettingsFromFile();
-        expect(settings.formatVersion).toBe('2');
+        expect(settings.formatVersion).toBe('3');
         expect(settings.directory.length).toBe(2);
         expect(settings.searchSettings.maxIndexableFileSize).toBe(102400);
+        expect(settings.checklistSettings.customItems.length).toBe(0);
         expect(fs.readFileSync).toHaveBeenCalledWith('.user-settings.json');
       });
       it('should throw an exception if the JSON is invalid', () => {
@@ -98,18 +119,30 @@ describe('services', () => {
         });
         const settings = new UserService().loadUserSettingsFromFile('/Test/Path');
         expect(settings).not.toBeNull();
-        expect(settings.formatVersion).toBe('2');
+        expect(settings.formatVersion).toBe('3');
         expect(settings.directory.length).toBe(0);
         expect(settings.searchSettings.maxIndexableFileSize).toBe(102400);
+        expect(settings.checklistSettings.customItems.length).toBe(0);
         expect(fs.readFileSync).not.toHaveBeenCalled();
       });
 
-      it('should upgrade from v1 to v2', () => {
+      it('should upgrade from v1 to v3', () => {
         fs.readFileSync.mockReturnValue(V1SettingsString);
         const settings = new UserService().loadUserSettingsFromFile();
-        expect(settings.formatVersion).toBe('2');
+        expect(settings.formatVersion).toBe('3');
         expect(settings.directory.length).toBe(2);
         expect(settings.searchSettings.maxIndexableFileSize).toBe(102400);
+        expect(settings.checklistSettings.customItems.length).toBe(0);
+        expect(fs.readFileSync).toHaveBeenCalledWith('.user-settings.json');
+      });
+
+      it('should upgrade from v2 to v3', () => {
+        fs.readFileSync.mockReturnValue(settingsString); // settingsString is v2
+        const settings = new UserService().loadUserSettingsFromFile();
+        expect(settings.formatVersion).toBe('3');
+        expect(settings.directory.length).toBe(2);
+        expect(settings.searchSettings.maxIndexableFileSize).toBe(102400);
+        expect(settings.checklistSettings.customItems.length).toBe(0);
         expect(fs.readFileSync).toHaveBeenCalledWith('.user-settings.json');
       });
     });
@@ -155,7 +188,7 @@ describe('services', () => {
             name: { first: 'T', last: 'P' },
           }),
         ).not.toBeNull();
-        expect(settings.formatVersion).toBe('2');
+        expect(settings.formatVersion).toBe('3');
         expect(settings.directory).not.toBeNull();
       });
       it('should add a new person when the id is provided', () => {
@@ -450,7 +483,7 @@ describe('services', () => {
           directory: [],
         };
         new UserService().removePersonFromUserDirectory(settings, { id: '1-2-3' });
-        expect(settings.formatVersion).toBe('2');
+        expect(settings.formatVersion).toBe('3');
       });
       it('should remove a person when matched on ID', () => {
         const settings = {

--- a/test/utils/checklist.spec.js
+++ b/test/utils/checklist.spec.js
@@ -3,6 +3,26 @@ import Constants from '../../app/constants/constants';
 
 describe('utils', () => {
   describe('ChecklistUtil', () => {
+    describe('initializeChecklist', () => {
+      it('should return default checklist items when no custom items are provided', () => {
+        const checklist = ChecklistUtil.initializeChecklist();
+        expect(checklist.length).toBe(Constants.CHECKLIST.length);
+        expect(checklist[0].name).toBe(Constants.CHECKLIST[0][0]);
+      });
+
+      it('should include custom items when provided', () => {
+        const customItems = [
+          { id: 'custom-1', name: 'Custom Name', statement: 'Custom Statement' },
+        ];
+        const checklist = ChecklistUtil.initializeChecklist(customItems);
+        expect(checklist.length).toBe(Constants.CHECKLIST.length + 1);
+        const lastItem = checklist[checklist.length - 1];
+        expect(lastItem.id).toBe('custom-1');
+        expect(lastItem.name).toBe('Custom Name');
+        expect(lastItem.statement).toBe('Custom Statement');
+      });
+    });
+
     describe('findProjectLanguagesAndDependencies', () => {
       it('should return empty result when asset is null or undefined', () => {
         expect(ChecklistUtil.findProjectLanguagesAndDependencies(null)).toEqual({});


### PR DESCRIPTION
 Summary
This PR implements the ability for users to configure global custom items for the Reproducibility Checklist, as requested in Issue 305.

 Key Changes:
- New UI :  Added a `ChecklistSettings` component integrated into the Configuration page for managing custom items (Add, Edit, Delete).
- Backend Persistence :  Updated `UserService` to v3 and added IPC handlers to store global checklist settings in `.user-settings.json`.
- Automatic Sync  :  Modified `ProjectPage` and `ChecklistUtil` to automatically push global custom items to project-level checklists whenever a project is loaded.
- Verification :  Updated unit tests for `UserService` and `ChecklistUtil` (all tests passing).

Fixes #305
