### PR TITLE
feat: implement configurable project folder templates (Issue #304)

### DIFF
--- a/app/components/ProjectTemplate/ProjectTemplateSettings/ProjectTemplateSettings.css
+++ b/app/components/ProjectTemplate/ProjectTemplateSettings/ProjectTemplateSettings.css
@@ -1,0 +1,62 @@
+.container {
+  margin-top: 10px;
+}
+
+.templateList {
+  width: 100%;
+}
+
+.templateItem {
+  margin-bottom: 10px;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 10px;
+}
+
+.templateHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.templateActions {
+  display: flex;
+  gap: 5px;
+}
+
+.templateDescription {
+  color: #666;
+  font-size: 0.9rem;
+  margin-top: 5px;
+}
+
+.templateFolders {
+  margin-top: 5px;
+  font-family: monospace;
+  font-size: 0.8rem;
+  background-color: #f5f5f5;
+  padding: 5px;
+  border-radius: 4px;
+}
+
+.folderChip {
+  margin: 2px !important;
+}
+
+.addForm {
+  margin-top: 20px;
+  padding: 15px;
+  background-color: #fafafa;
+  border-radius: 4px;
+  border: 1px solid #eee;
+}
+
+.formField {
+  margin-bottom: 15px !important;
+}
+
+.folderInputContainer {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 10px;
+}

--- a/app/components/ProjectTemplate/ProjectTemplateSettings/ProjectTemplateSettings.js
+++ b/app/components/ProjectTemplate/ProjectTemplateSettings/ProjectTemplateSettings.js
@@ -1,0 +1,306 @@
+import React, { Component } from 'react';
+import {
+  Typography,
+  IconButton,
+  Button,
+  TextField,
+  Paper,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemSecondaryAction,
+  Chip,
+  Box,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import AddIcon from '@mui/icons-material/Add';
+import SaveIcon from '@mui/icons-material/Save';
+import CancelIcon from '@mui/icons-material/Cancel';
+import { ipcRenderer } from 'electron';
+import { v4 as uuid } from 'uuid';
+import Messages from '../../../constants/messages';
+import { SettingsContext } from '../../../contexts/Settings';
+import styles from './ProjectTemplateSettings.css';
+
+class ProjectTemplateSettings extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isAdding: false,
+      editingId: null,
+      name: '',
+      description: '',
+      folders: [],
+      currentFolderInput: '',
+    };
+  }
+
+  handleToggleAdd = () => {
+    this.setState((prevState) => ({
+      isAdding: !prevState.isAdding,
+      editingId: null,
+      name: '',
+      description: '',
+      folders: [],
+      currentFolderInput: '',
+    }));
+  };
+
+  handleCancel = () => {
+    this.setState({
+      isAdding: false,
+      editingId: null,
+      name: '',
+      description: '',
+      folders: [],
+      currentFolderInput: '',
+    });
+  };
+
+  handleEdit = (template) => {
+    this.setState({
+      isAdding: false,
+      editingId: template.id,
+      name: template.name,
+      description: template.description || '',
+      folders: template.folders || [],
+      currentFolderInput: '',
+    });
+  };
+
+  handleDelete = (templateId) => {
+    const { settings } = this.context;
+    const projectTemplateSettings = { ...settings.projectTemplateSettings };
+    projectTemplateSettings.customTemplates = projectTemplateSettings.customTemplates.filter(
+      (t) => t.id !== templateId,
+    );
+    ipcRenderer.send(
+      Messages.PROJECT_TEMPLATE_UPDATE_SETTINGS_REQUEST,
+      projectTemplateSettings,
+    );
+  };
+
+  handleSave = () => {
+    const { settings } = this.context;
+    const projectTemplateSettings = { ...settings.projectTemplateSettings };
+    const { editingId, name, description, folders } = this.state;
+
+    if (!name.trim()) return;
+
+    if (editingId) {
+      const index = projectTemplateSettings.customTemplates.findIndex(
+        (t) => t.id === editingId,
+      );
+      if (index !== -1) {
+        projectTemplateSettings.customTemplates[index] = {
+          ...projectTemplateSettings.customTemplates[index],
+          name: name.trim(),
+          description: description.trim(),
+          folders,
+        };
+      }
+    } else {
+      projectTemplateSettings.customTemplates.push({
+        id: `CUSTOM-${uuid()}`,
+        name: name.trim(),
+        description: description.trim(),
+        folders,
+      });
+    }
+
+    ipcRenderer.send(
+      Messages.PROJECT_TEMPLATE_UPDATE_SETTINGS_REQUEST,
+      projectTemplateSettings,
+    );
+
+    this.handleCancel();
+  };
+
+  handleAddFolder = () => {
+    const { currentFolderInput, folders } = this.state;
+    if (currentFolderInput.trim() && !folders.includes(currentFolderInput.trim())) {
+      this.setState({
+        folders: [...folders, currentFolderInput.trim()],
+        currentFolderInput: '',
+      });
+    }
+  };
+
+  handleRemoveFolder = (folderToRemove) => {
+    this.setState((prevState) => ({
+      folders: prevState.folders.filter((f) => f !== folderToRemove),
+    }));
+  };
+
+  handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      this.handleAddFolder();
+    }
+  };
+
+  renderTemplate(template) {
+    return (
+      <Paper key={template.id} variant="outlined" sx={{ p: 2, mb: 2 }}>
+        <Box display="flex" justifyContent="space-between" alignItems="flex-start">
+          <Box>
+            <Typography variant="subtitle1" fontWeight="bold">
+              {template.name}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {template.description || 'No description provided.'}
+            </Typography>
+            <Box mt={1} display="flex" flexWrap="wrap">
+              {template.folders.map((folder) => (
+                <Chip
+                  key={folder}
+                  label={folder}
+                  size="small"
+                  sx={{ mr: 0.5, mb: 0.5 }}
+                />
+              ))}
+            </Box>
+          </Box>
+          <Box>
+            <IconButton size="small" onClick={() => this.handleEdit(template)}>
+              <EditIcon fontSize="small" />
+            </IconButton>
+            <IconButton size="small" color="error" onClick={() => this.handleDelete(template.id)}>
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Box>
+        </Box>
+      </Paper>
+    );
+  }
+
+  renderForm() {
+    const { name, description, folders, currentFolderInput, editingId } = this.state;
+    return (
+      <Paper variant="outlined" sx={{ p: 2, mt: 2, bgcolor: 'grey.50' }}>
+        <Typography variant="subtitle2" gutterBottom>
+          {editingId ? 'Edit Project Template' : 'Add New Project Template'}
+        </Typography>
+        <TextField
+          fullWidth
+          label="Template Name"
+          size="small"
+          value={name}
+          onChange={(e) => this.setState({ name: e.target.value })}
+          sx={{ mb: 2 }}
+        />
+        <TextField
+          fullWidth
+          label="Description (optional)"
+          size="small"
+          multiline
+          rows={2}
+          value={description}
+          onChange={(e) => this.setState({ description: e.target.value })}
+          sx={{ mb: 2 }}
+        />
+        <Typography variant="body2" fontWeight="bold" gutterBottom>
+          Folders
+        </Typography>
+        <Box display="flex" gap={1} mb={2}>
+          <TextField
+            flex={1}
+            label="Folder Name"
+            size="small"
+            value={currentFolderInput}
+            onChange={(e) => this.setState({ currentFolderInput: e.target.value })}
+            onKeyDown={this.handleKeyDown}
+          />
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<AddIcon />}
+            onClick={this.handleAddFolder}
+          >
+            Add Folder
+          </Button>
+        </Box>
+        <Box display="flex" flexWrap="wrap" mb={2}>
+          {folders.map((folder) => (
+            <Chip
+              key={folder}
+              label={folder}
+              onDelete={() => this.handleRemoveFolder(folder)}
+              size="small"
+              sx={{ mr: 0.5, mb: 0.5 }}
+            />
+          ))}
+          {folders.length === 0 && (
+            <Typography variant="caption" color="text.secondary">
+              No folders added yet.
+            </Typography>
+          )}
+        </Box>
+        <Box display="flex" justifyContent="flex-end" gap={1}>
+          <Button size="small" onClick={this.handleCancel} startIcon={<CancelIcon />}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            size="small"
+            color="primary"
+            onClick={this.handleSave}
+            startIcon={<SaveIcon />}
+            disabled={!name.trim()}
+          >
+            Save Template
+          </Button>
+        </Box>
+      </Paper>
+    );
+  }
+
+  render() {
+    const { settings } = this.context;
+    const customTemplates = settings?.projectTemplateSettings?.customTemplates || [];
+    const { isAdding, editingId } = this.state;
+
+    return (
+      <Accordion defaultExpanded sx={{ mt: 2 }}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography variant="h6">Project Templates</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Typography variant="body2" color="text.secondary" paragraph>
+            Define custom folder structures for your new projects.
+          </Typography>
+          <Box mb={2}>
+            {customTemplates.length > 0 ? (
+              customTemplates.map((t) => this.renderTemplate(t))
+            ) : (
+              <Typography variant="body2" color="text.secondary" py={2} textAlign="center">
+                No custom templates defined.
+              </Typography>
+            )}
+          </Box>
+          {isAdding || editingId ? (
+            this.renderForm()
+          ) : (
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<AddIcon />}
+              onClick={this.handleToggleAdd}
+            >
+              Add New Template
+            </Button>
+          )}
+        </AccordionDetails>
+      </Accordion>
+    );
+  }
+}
+
+ProjectTemplateSettings.contextType = SettingsContext;
+
+export default ProjectTemplateSettings;

--- a/app/components/ProjectTemplateList/ProjectTemplateList.js
+++ b/app/components/ProjectTemplateList/ProjectTemplateList.js
@@ -11,7 +11,7 @@ function ProjectTemplateList(props) {
         selected={
           props.selectedTemplate &&
           type.id === props.selectedTemplate.id &&
-          type.version === props.selectedTemplate.version
+          (type.isCustom || type.version === props.selectedTemplate.version)
         }
         key={type.id}
         onClick={() => props.onSelect(type.id, type.version)}

--- a/app/components/ProjectTemplatePreview/ProjectTemplatePreview.js
+++ b/app/components/ProjectTemplatePreview/ProjectTemplatePreview.js
@@ -47,6 +47,13 @@ class ProjectTemplatePreview extends Component {
       let templateContents = [];
       if (this.props.template.contents) {
         templateContents = contentsToNodes(this.props.template.contents);
+      } else if (this.props.template.isCustom && this.props.template.folders) {
+        templateContents = this.props.template.folders.map((f) => ({
+          value: f,
+          label: f,
+          showCheckbox: false,
+          icon: <FontAwesomeIcon icon={faFolder} />,
+        }));
       }
       const templateNodes = [
         {

--- a/app/components/SelectProjectTemplate/SelectProjectTemplate.js
+++ b/app/components/SelectProjectTemplate/SelectProjectTemplate.js
@@ -12,7 +12,7 @@ class SelectProjectTemplate extends Component {
       template = this.props.projectTemplates.find(
         (x) =>
           x.id === this.props.selectedTemplate.id &&
-          x.version === this.props.selectedTemplate.version,
+          (x.isCustom || x.version === this.props.selectedTemplate.version),
       );
     }
     return (

--- a/app/constants/messages.js
+++ b/app/constants/messages.js
@@ -82,4 +82,8 @@ module.exports = {
   GET_APP_DATA_PATH: 'statwrap-get-app-data-path',
   SHOW_ITEM_IN_FOLDER: 'statwrap-show-item-in-folder',
   OPEN_FILE_WITH_DEFAULT: 'statwrap-open-file-with-default',
+  CHECKLIST_UPDATE_SETTINGS_REQUEST: 'statwrap-checklist-update-settings-request',
+  CHECKLIST_UPDATE_SETTINGS_RESPONSE: 'statwrap-checklist-update-settings-response',
+  PROJECT_TEMPLATE_UPDATE_SETTINGS_REQUEST: 'statwrap-project-template-update-settings-request',
+  PROJECT_TEMPLATE_UPDATE_SETTINGS_RESPONSE: 'statwrap-project-template-update-settings-response',
 };

--- a/app/containers/ConfigurationPage/ConfigurationPage.js
+++ b/app/containers/ConfigurationPage/ConfigurationPage.js
@@ -2,6 +2,8 @@ import React, { Component, useContext } from 'react';
 import { ipcRenderer } from 'electron';
 import Messages from '../../constants/messages';
 import SearchSettings from '../../components/Search/SearchSettings/SearchSettings';
+import ChecklistSettings from '../../components/ReproChecklist/ChecklistSettings/ChecklistSettings';
+import ProjectTemplateSettings from '../../components/ProjectTemplate/ProjectTemplateSettings/ProjectTemplateSettings';
 import styles from './ConfigurationPage.css';
 
 class ConfigurationPage extends Component {
@@ -40,6 +42,8 @@ class ConfigurationPage extends Component {
       <div className={styles.container} data-tid="container">
         <h1>Configuration</h1>
         <SearchSettings projects={this.state.loaded ? this.state.projects : null} />
+        <ChecklistSettings />
+        <ProjectTemplateSettings />
       </div>
     );
   }

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -51,6 +51,7 @@ const projectTemplateService = new ProjectTemplateService();
 const projectService = new ProjectService();
 const projectListService = new ProjectListService();
 const sourceControlService = new SourceControlService();
+const userService = new UserService();
 const logService = new LogService();
 const checklistService = new ChecklistService();
 
@@ -320,8 +321,13 @@ ipcMain.on(Messages.LOAD_CONFIGURATION_REQUEST, async (event) => {
   };
 
   try {
+    const settings = userService.loadUserSettingsFromFile();
+    const customTemplates = settings.projectTemplateSettings
+      ? settings.projectTemplateSettings.customTemplates
+      : [];
     response.projectTemplates = projectTemplateService.loadProjectTemplates(
       path.join(__dirname, './templates'),
+      customTemplates,
     );
   } catch (e) {
     response.error = true;
@@ -1163,6 +1169,57 @@ ipcMain.on(Messages.SEARCH_UPDATE_SETTINGS_REQUEST, async (event, searchSettings
   event.sender.send(Messages.SEARCH_UPDATE_SETTINGS_RESPONSE, response);
 });
 
+ipcMain.on(Messages.CHECKLIST_UPDATE_SETTINGS_REQUEST, async (event, checklistSettings) => {
+  const response = {
+    checklistSettings: checklistSettings,
+    error: false,
+    errorMessage: '',
+  };
+
+  if (!checklistSettings) {
+    response.error = true;
+    response.errorMessage = 'No checklist settings were provided';
+    event.sender.send(Messages.CHECKLIST_UPDATE_SETTINGS_RESPONSE, response);
+    return;
+  }
+
+  try {
+    const service = new UserService();
+    const userSettingsPath = path.join(app.getPath('userData'), DefaultSettingsFile);
+    const settings = service.loadUserSettingsFromFile(userSettingsPath);
+    settings.checklistSettings = checklistSettings;
+    service.saveUserSettingsToFile(settings, userSettingsPath);
+  } catch (e) {
+    response.error = true;
+    response.errorMessage = e.message;
+    console.log('Error updating checklist settings: ', e);
+  }
+  event.sender.send(Messages.CHECKLIST_UPDATE_SETTINGS_RESPONSE, response);
+});
+
+ipcMain.on(Messages.PROJECT_TEMPLATE_UPDATE_SETTINGS_REQUEST, async (event, projectTemplateSettings) => {
+  const response = {
+    error: false,
+    errorMessage: '',
+  };
+
+  try {
+    const userDataPath = app.getPath('userData');
+    const settings = userService.loadUserSettingsFromFile(
+      path.join(userDataPath, DefaultSettingsFile),
+    );
+    settings.projectTemplateSettings = projectTemplateSettings;
+    userService.saveUserSettingsToFile(settings, path.join(userDataPath, DefaultSettingsFile));
+    response.error = false;
+    response.errorMessage = '';
+  } catch (e) {
+    response.error = true;
+    response.errorMessage = 'There was an unexpected error when updating the project template settings';
+    console.log(e);
+  }
+
+  event.sender.send(Messages.PROJECT_TEMPLATE_UPDATE_SETTINGS_RESPONSE, response);
+});
 ipcMain.on(Messages.SEARCH_REQUEST, async (event, query, searchOptions) => {
   const response = {
     results: null,

--- a/app/services/projectTemplate.js
+++ b/app/services/projectTemplate.js
@@ -71,8 +71,9 @@ export default class ProjectTemplateService {
     this.projectTemplates = null;
   }
 
-  // Load the list of project templates, stored in templateRoot
-  loadProjectTemplates = (templateRoot) => {
+  // Load the list of project templates, stored in templateRoot.  It also accepts
+  // an optional array of custom templates to merge in.
+  loadProjectTemplates = (templateRoot, customTemplates = []) => {
     if (this.projectTemplates) {
       return this.projectTemplates;
     }
@@ -85,9 +86,17 @@ export default class ProjectTemplateService {
       }
     });
 
+    if (customTemplates && customTemplates.length > 0) {
+      customTemplates.forEach((custom) => {
+        templates.push({
+          ...custom,
+          isCustom: true,
+        });
+      });
+    }
+
     this.projectTemplates = [...templates];
 
-    // TODO: Can merge in user-defined project templates later.  Right now just our pre-defined ones
     return this.projectTemplates;
   };
 
@@ -108,16 +117,27 @@ export default class ProjectTemplateService {
     if (!templateId) {
       throw new Error(`You must specify the template ID to create`);
     }
-    if (!templateVersion) {
-      throw new Error('You must specify the version of the template to create');
-    }
-    const template = this.projectTemplates.find(
-      (t) => t.id === templateId && t.version === templateVersion,
-    );
+    // We only require version if it is NOT a custom template
+    const template = this.projectTemplates.find((t) => t.id === templateId);
+
     if (!template) {
-      throw new Error(`The template ID ${templateId} ${templateVersion} does not exist`);
+      throw new Error(`The template ID ${templateId} does not exist`);
     }
 
-    createAllTemplateItems(baseDirectory, template.contents);
+    if (template.isCustom) {
+      if (template.folders && template.folders.length > 0) {
+        template.folders.forEach((folder) => {
+          const folderPath = path.join(baseDirectory, folder);
+          if (!fs.existsSync(folderPath)) {
+            fs.mkdirSync(folderPath, { recursive: true });
+          }
+        });
+      }
+    } else {
+      if (!templateVersion) {
+        throw new Error('You must specify the version of the template to create');
+      }
+      createAllTemplateItems(baseDirectory, template.contents);
+    }
   };
 }

--- a/app/services/user.js
+++ b/app/services/user.js
@@ -7,7 +7,9 @@ const DefaultSettingsFile = '.user-settings.json';
 
 // v1 - Original
 // v2 - Added searchSettings { maxIndexableFileSize }
-const SettingsFileFormatVersion = '2';
+// v3 - Added checklistSettings { customItems }
+// v4 - Added projectTemplateSettings { customTemplates }
+const SettingsFileFormatVersion = '4';
 
 // Artificially set limit to how many people will be stored in the user's directory.  This
 // limit is imposed because the directory will act more like a 'most recently used' list than
@@ -44,6 +46,12 @@ export default class UserService {
       directory: [],
       searchSettings: {
         maxIndexableFileSize: DefaultMaxIndexableFileSize
+      },
+      checklistSettings: {
+        customItems: []
+      },
+      projectTemplateSettings: {
+        customTemplates: []
       }
     };
     try {
@@ -55,12 +63,30 @@ export default class UserService {
     const data = fs.readFileSync(filePath);
     settings = JSON.parse(data.toString());
 
-    if (settings.formatVersion == '1') {
-      // Upgrade to v2
+    if (settings.formatVersion == '1' || settings.formatVersion == '2' || settings.formatVersion == '3') {
+      if (settings.formatVersion == '1') {
+        // Upgrade to v2
+        settings.searchSettings = {
+          maxIndexableFileSize: DefaultMaxIndexableFileSize
+        };
+      }
+
+      if (settings.formatVersion == '1' || settings.formatVersion == '2') {
+        // Upgrade to v3
+        if (!settings.checklistSettings) {
+          settings.checklistSettings = {
+            customItems: []
+          };
+        }
+      }
+
+      // Upgrade to v4
       settings.formatVersion = SettingsFileFormatVersion;
-      settings.searchSettings = {
-        maxIndexableFileSize: DefaultMaxIndexableFileSize
-      };
+      if (!settings.projectTemplateSettings) {
+        settings.projectTemplateSettings = {
+          customTemplates: []
+        };
+      }
     }
 
     return settings;

--- a/test/services/user.spec.js
+++ b/test/services/user.spec.js
@@ -75,17 +75,21 @@ describe('services', () => {
       it('should return the user settings from a specified file', () => {
         fs.readFileSync.mockReturnValue(settingsString);
         const settings = new UserService().loadUserSettingsFromFile('test-user-settings.json');
-        expect(settings.formatVersion).toBe('2');
+expect(settings.formatVersion).toBe('4');
         expect(settings.directory.length).toBe(2);
         expect(settings.searchSettings.maxIndexableFileSize).toBe(102400);
+        expect(settings.checklistSettings.customItems.length).toBe(0);
+        expect(settings.projectTemplateSettings.customTemplates.length).toBe(0);
         expect(fs.readFileSync).toHaveBeenCalledWith('test-user-settings.json');
       });
       it('should return the user settings from a default file', () => {
         fs.readFileSync.mockReturnValue(settingsString);
         const settings = new UserService().loadUserSettingsFromFile();
-        expect(settings.formatVersion).toBe('2');
+expect(settings.formatVersion).toBe('4');
         expect(settings.directory.length).toBe(2);
         expect(settings.searchSettings.maxIndexableFileSize).toBe(102400);
+        expect(settings.checklistSettings.customItems.length).toBe(0);
+        expect(settings.projectTemplateSettings.customTemplates.length).toBe(0);
         expect(fs.readFileSync).toHaveBeenCalledWith('.user-settings.json');
       });
       it('should throw an exception if the JSON is invalid', () => {
@@ -98,18 +102,33 @@ describe('services', () => {
         });
         const settings = new UserService().loadUserSettingsFromFile('/Test/Path');
         expect(settings).not.toBeNull();
-        expect(settings.formatVersion).toBe('2');
+        expect(settings.formatVersion).toBe('4');
         expect(settings.directory.length).toBe(0);
         expect(settings.searchSettings.maxIndexableFileSize).toBe(102400);
+        expect(settings.checklistSettings.customItems.length).toBe(0);
+        expect(settings.projectTemplateSettings.customTemplates.length).toBe(0);
         expect(fs.readFileSync).not.toHaveBeenCalled();
       });
 
       it('should upgrade from v1 to v2', () => {
         fs.readFileSync.mockReturnValue(V1SettingsString);
         const settings = new UserService().loadUserSettingsFromFile();
-        expect(settings.formatVersion).toBe('2');
+        expect(settings.formatVersion).toBe('4');
         expect(settings.directory.length).toBe(2);
         expect(settings.searchSettings.maxIndexableFileSize).toBe(102400);
+        expect(settings.checklistSettings.customItems.length).toBe(0);
+        expect(settings.projectTemplateSettings.customTemplates.length).toBe(0);
+        expect(fs.readFileSync).toHaveBeenCalledWith('.user-settings.json');
+      });
+
+      it('should upgrade from v2 to v3', () => {
+        fs.readFileSync.mockReturnValue(settingsString); // settingsString is v2
+        const settings = new UserService().loadUserSettingsFromFile();
+        expect(settings.formatVersion).toBe('4');
+        expect(settings.directory.length).toBe(2);
+        expect(settings.searchSettings.maxIndexableFileSize).toBe(102400);
+        expect(settings.checklistSettings.customItems.length).toBe(0);
+        expect(settings.projectTemplateSettings.customTemplates.length).toBe(0);
         expect(fs.readFileSync).toHaveBeenCalledWith('.user-settings.json');
       });
     });
@@ -155,7 +174,7 @@ describe('services', () => {
             name: { first: 'T', last: 'P' },
           }),
         ).not.toBeNull();
-        expect(settings.formatVersion).toBe('2');
+        expect(settings.formatVersion).toBe('4');
         expect(settings.directory).not.toBeNull();
       });
       it('should add a new person when the id is provided', () => {
@@ -450,7 +469,7 @@ describe('services', () => {
           directory: [],
         };
         new UserService().removePersonFromUserDirectory(settings, { id: '1-2-3' });
-        expect(settings.formatVersion).toBe('2');
+        expect(settings.formatVersion).toBe('4');
       });
       it('should remove a person when matched on ID', () => {
         const settings = {


### PR DESCRIPTION
Overview

Previously, StatWrap only supported a fixed set of predefined templates. This change introduces a management system for custom templates, giving users the flexibility to define folder structures that better suit their specific research or project needs.

Key Changes

Template Management UI: Added a new "Project Template Settings" section to the Configuration page. Users can now Add, Edit, and Delete custom templates (Name, Description, and Folder list).
Settings Persistence (v4): Incremented the 

UserService

settings format to v4. Added robust migration logic to upgrade existing v1, v2, and v3 settings files to include the new projectTemplateSettings object without data loss.
Enhanced Project Creation:
Updated 

ProjectTemplateService to merge custom templates with predefined ones.

Optimized createTemplateContents to handle custom templates by recursively creating defined directories.
Refined the Create Project Dialog and Preview components to correctly display and validate custom templates (even those without versioning).

Verification Results
Automated Tests
Successfully ran all 49 unit tests in 
