### PR TITLE
Fixed Notes content overflow

### DIFF
--- a/app/components/NoteEditor/Note/Note.css
+++ b/app/components/NoteEditor/Note/Note.css
@@ -15,6 +15,8 @@
 .content,
 .emptyContent {
   white-space: pre-wrap;
+  overflow-wrap: break-word;
+  display: block;
   font-size: 0.9rem;
 }
 


### PR DESCRIPTION
### Description : 
While going through the StatWrap, I found that when we type the sentences a little bit longer , the text/words comes out of the box after clicking.

### Fixes 
Fixes #329 

### Changes : 

- Added overflow-wrap: break-word & display: block in the Note.css
