### PR TITLE
Added saving roles by clicking save button

### DIFF
--- a/app/components/TagEditor/TagEditor.js
+++ b/app/components/TagEditor/TagEditor.js
@@ -3,6 +3,7 @@ import TagsInput from 'react-tagsinput';
 
 const tagEditor = (props) => {
   const [tags, setTags] = useState(props.tags);
+  const [inputValue, setInputValue] = useState('');
 
   const changedTagsHandler = (updatedTags) => {
     setTags(updatedTags);
@@ -11,10 +12,19 @@ const tagEditor = (props) => {
     }
   };
 
+  const changedInputHandler = (value) => {
+    setInputValue(value);
+    if (props.onInputChange) {
+      props.onInputChange(value);
+    }
+  };
+
   return (
     <TagsInput
       value={tags}
       onChange={changedTagsHandler}
+      inputValue={inputValue}
+      onChangeInput={changedInputHandler}
       onlyUnique
       inputProps={{ placeholder: 'Add a topic' }}
     />

--- a/app/containers/CreateUpdatePersonDialog/CreateUpdatePersonDialog.js
+++ b/app/containers/CreateUpdatePersonDialog/CreateUpdatePersonDialog.js
@@ -38,10 +38,12 @@ class CreateUpdatePersonDialog extends Component {
       lastName: props.name ? props.name.last : '',
       affiliation: props.affiliation ? props.affiliation : '',
       roles: props.roles ? props.roles : [],
+      pendingRoleInput: '',
     };
 
     this.handleInputChange = this.handleInputChange.bind(this);
     this.handleRolesChanged = this.handleRolesChanged.bind(this);
+    this.handleRolesInputChanged = this.handleRolesInputChanged.bind(this);
     this.handleCreateUpdatePerson = this.handleCreateUpdatePerson.bind(this);
     this.handleCreateUpdatePersonCompleted = this.handleCreateUpdatePersonCompleted.bind(this);
     this.handleSelectPersonInDirectory = this.handleSelectPersonInDirectory.bind(this);
@@ -79,6 +81,13 @@ class CreateUpdatePersonDialog extends Component {
   }
 
   handleCreateUpdatePerson() {
+    // If there is uncommitted text in the roles input, include it as a role
+    let { roles } = this.state;
+    const pending = this.state.pendingRoleInput.trim();
+    if (pending && !roles.includes(pending)) {
+      roles = [...roles, pending];
+    }
+
     const person = {
       id: this.state.id,
       name: {
@@ -86,13 +95,17 @@ class CreateUpdatePersonDialog extends Component {
         last: this.state.lastName,
       },
       affiliation: this.state.affiliation,
-      roles: this.state.roles,
+      roles,
     };
     this.savePerson(person);
   }
 
   handleRolesChanged(changedRoles) {
-    this.setState({ roles: changedRoles });
+    this.setState({ roles: changedRoles, pendingRoleInput: '' });
+  }
+
+  handleRolesInputChanged(value) {
+    this.setState({ pendingRoleInput: value });
   }
 
   handleInputChange(event) {
@@ -133,7 +146,7 @@ class CreateUpdatePersonDialog extends Component {
       roles = (
         <div className={styles.formRow}>
           <label className={styles.personLabel}>Roles:</label>
-          <TagEditor tags={this.state.roles} onChange={this.handleRolesChanged} />
+          <TagEditor tags={this.state.roles} onChange={this.handleRolesChanged} onInputChange={this.handleRolesInputChanged} />
         </div>
       );
     }


### PR DESCRIPTION
### Description : 
Currently when user gives the input in the roles and click on the Save button , it does not saves this.Explicitly , we requires to press the Tab/Enter. This pr adds when the user click on Save button after giving the role ,  it saves this.


### Fixes : 
Fixes #330 

### Changes : 

- In TagEditor.js : Added inputValue and onChangeInputValue for tracking input field & also added onInputChange.
- In CreateUpdatePersonDialog.js : Added pendingRoleInput state & handlesRolesInputChanged wired to new onInputChange. & updated handleCreateUpdatePerson.