### PR TITLE
Additional filtering for dependency view

### DIFF
--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -109,6 +109,7 @@ module.exports = {
     FILE_TYPE: 'File Type',
     CONTENT_TYPE: 'Content Type',
     ASSET_TYPE: 'Asset Type',
+    DIRECTORY: 'Directory',
     INPUTS_OUTPUTS: 'Inputs and Outputs',
     DEPENDENCIES: 'Dependencies/Libraries',
     ATTRIBUTE: 'Attribute',

--- a/app/utils/project.js
+++ b/app/utils/project.js
@@ -350,6 +350,26 @@ export default class ProjectUtil {
       filters.push(fileTypeFilter);
     }
 
+        const directoryFilter = { category: Constants.FilterCategory.DIRECTORY, values: [] };
+    const rootPath = filteredAssets.uri;
+    const directoryFunc = (x) => {
+      if (x.type === Constants.AssetType.DIRECTORY || x.type === Constants.AssetType.FOLDER) {
+        if (x.uri && x.uri !== rootPath) {
+          const relPath = AssetUtil.absoluteToRelativePath(rootPath, x);
+          if (relPath) {
+            return relPath;
+          }
+        }
+      }
+      return null;
+    };
+    ProjectUtil._processAssetAndDescendantsForFilter(
+      filteredAssets,
+      directoryFilter,
+      directoryFunc,
+    );
+    ProjectUtil._sortAndAddFilter(directoryFilter, filters);
+    
     // We get back a flat list of dependencies, so no recursive processing is needed for these
     const ioFilter = { category: Constants.FilterCategory.INPUTS_OUTPUTS, values: [] };
     const dependencyFilter = { category: Constants.FilterCategory.DEPENDENCIES, values: [] };

--- a/app/utils/workflow.js
+++ b/app/utils/workflow.js
@@ -150,6 +150,10 @@ export default class WorkflowUtil {
       ? filters.findIndex((x) => x.category === Constants.FilterCategory.ATTRIBUTE)
       : -1;
     const attributeFilter = attributeFilterIndex === -1 ? null : filters[attributeFilterIndex];
+    const directoryFilterIndex = applyFilter
+      ? filters.findIndex((x) => x.category === Constants.FilterCategory.DIRECTORY)
+      : -1;
+    const directoryFilter = directoryFilterIndex === -1 ? null : filters[directoryFilterIndex];
 
     const allDeps = WorkflowUtil.getAllDependencies(filteredAsset, filteredAsset.uri);
     // Create a map of relative URIs to assets for faster lookup
@@ -186,6 +190,19 @@ export default class WorkflowUtil {
             if (shouldFilter) {
               continue;
             }
+          }
+        }
+
+        if (directoryFilter) {
+          const normalizedAsset = entry.asset.split('\\').join('/');
+          const shouldFilter = directoryFilter.values.some((v) => {
+            if (!v.value) {
+              return normalizedAsset === v.key || normalizedAsset.startsWith(v.key + '/');
+            }
+            return false;
+          });
+          if (shouldFilter) {
+            continue;
           }
         }
 


### PR DESCRIPTION
### Description 
Currently there is no filter based on the Directory for the Dependency view.So this pr adds Directory filter in the dependency view.

### Fixes 
Fixes #142 

### Changes : 

- constants.js : Added Directory to standard filter categories.
- project.js : Added the logic to scan and create list of paths.
- workflow.js : Excludes assets from the dependency view if they belong to a filtered directory.

### Screen Recording : 


https://github.com/user-attachments/assets/696ddb92-f500-493d-acf8-563dff1ca73d




