### PR TITLE
fixes the note component

### DIFF
--- a/app/components/NoteEditor/Note/Note.css
+++ b/app/components/NoteEditor/Note/Note.css
@@ -26,6 +26,9 @@
 
 .contentEditor {
   min-height: 100px;
+  max-width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
 }
 
 .icon {


### PR DESCRIPTION
## Description 
The note component was exceeds the parent component , but now It's not be able to exceeds the parent component.

## Related Issue 
Issue #333 

## Screen Recording 
https://github.com/user-attachments/assets/ec0eaebe-119e-454e-873d-2b8e54b717bb

## Explanation

Initially this issue can be solved by 2 ways :- 

1. In this approach we will make parent component flexible too, So It will adjust as we adjust the note component but there's catch in this that note component is not only used in a single page as same width or same size. It's used on different pages like (`notes on projet` and `notes by people` and `notes on dashboard` page too) and By default on other page It takes whole screen. So making parent component flexible will result to bad UX.

2. In this approach we fix the width of note component. So It doesn't able to exceeds the parent component. The data in the note will have full visibility. This is the approach I decided to go.