### PR TITLE
fix: dashboard input bar

### DIFF
--- a/app/app.global.css
+++ b/app/app.global.css
@@ -87,31 +87,35 @@ body {
   border: solid 1px #1f3195 !important;
 }
 
+.react-tagsinput-input {
+  width: 100% !important;
+}
+
 #graph-id-graph-wrapper {
   width: inherit;
   height: inherit;
 }
 
 .tabIndicator {
-  background-color: 'white';
+  background-color: white;
 }
 
 .scrollButtons {
-  color: 'white';
+  color: white;
 }
 
 .tabRoot {
-  background-color: '#cccccc';
-  border: 'solid 1px #000';
-  font-size: '0.8rem';
+  background-color: #ccc;
+  border: solid 1px #000;
+  font-size: 0.8rem;
 }
 
 .tabSelected {
-  background-color: '#ffffff';
-  color: '#000000';
-  font-size: '0.9rem';
+  background-color: #fff;
+  color: #000;
+  font-size: 0.9rem;
 }
 
 .tabPanel {
-  padding: '10px';
+  padding: 10px;
 }


### PR DESCRIPTION
## Description
The dashboards additional details input now covering 100% of its working space previously It was only covering 10% of its working space and rest of it was blocked.

## Related Issues
Fixes #338 

## ScrrenShots
![WhatsApp Image 2026-03-15 at 11 23 09 AM](https://github.com/user-attachments/assets/dcc70ad0-b12b-40fb-9f51-028690b70f34)

## Additional Fixes 
while committing the msgs it was failing some test `✖ stylelint --ignore-path .eslintignore --fix:`
so the reason was, In `./app/app.global.css`  css value was written in `''` comma which is not correct 
So had to fix that too 
