### PR TITLE
fix the project name clipping issue for longer project names

### DIFF
--- a/app/components/Workflow/DependencyTree/DependencyTreeEChart.js
+++ b/app/components/Workflow/DependencyTree/DependencyTreeEChart.js
@@ -25,8 +25,9 @@ const dependencyGraphEChart = (props) => {
           edgeForkPosition: '63%',
           initialTreeDepth: 2,
           label: {
-            position: 'left',
-            align: 'right',
+            // Keep labels on the node's right to avoid clipping long root names.
+            position: 'right',
+            align: 'left',
           },
           leaves: {
             label: {


### PR DESCRIPTION
<img width="1919" height="1079" alt="Screenshot 2026-03-15 171418" src="https://github.com/user-attachments/assets/7c12e921-1308-4295-be29-b5d6edd207e1" />
