### PR TITLE
fix: remove duplicate URL key in AssetType constant

### DIFF
--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -24,7 +24,6 @@ module.exports = {
     FILE: 'file',
     URL: 'url',
     GENERIC: 'generic',
-    URL: 'url',
 
     // These are not a real asset types, but are used in our various controls
     ASSET_GROUP: 'asset-group',


### PR DESCRIPTION
## Summary

Fixes #348

Removes the duplicate `URL: 'url'` entry in the `AssetType` constant object in `app/constants/constants.js`.

## Context

The `AssetType` object had `URL: 'url'` defined twice with no comment explaining the duplication. Unlike the intentional `FOLDER`/`DIRECTORY` alias (which has an explanatory comment), the duplicate `URL` key served no purpose and caused linters to flag it as an error in strict mode.