### PR TITLE
fix: correctly increment userProfileDialogKey in setState

### DIFF
--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -97,7 +97,7 @@ export default class App extends React.Component {
       user: response.user,
       displayName: GeneralUtil.formatDisplayName(response.settings.user),
       settings: response.settings,
-      userProfileDialogKey: prevState + 1,
+      userProfileDialogKey: prevState.userProfileDialogKey + 1,
       displayUserProfileDialog: firstTimeRun,
     }));
   }


### PR DESCRIPTION
## Summary

Fixes #347

Corrects the `userProfileDialogKey` increment inside the `setState` callback in `app/containers/App.js`.

## Context

Inside a `setState` functional updater, `prevState` refers to the entire
state object, not a single value. Using `prevState + 1` produced
`"[object Object]1"` via string concatenation, meaning the key never
actually changed between calls. The dialog component was therefore never
properly re-mounted between sessions.