### PR TITLE
style: remove dead css code in app.global.css

### DIFF
--- a/app/app.global.css
+++ b/app/app.global.css
@@ -95,27 +95,3 @@ body {
   width: inherit;
   height: inherit;
 }
-
-.tabIndicator {
-  background-color: white;
-}
-
-.scrollButtons {
-  color: white;
-}
-
-.tabRoot {
-  background-color: #ccc;
-  border: solid 1px #000;
-  font-size: 0.8rem;
-}
-
-.tabSelected {
-  background-color: #fff;
-  color: #000;
-  font-size: 0.9rem;
-}
-
-.tabPanel {
-  padding: 10px;
-}


### PR DESCRIPTION
## Description
In app.global.css Several tab-related CSS classes (.tabIndicator, .scrollButtons, .tabRoot, .tabSelected, .tabPanel) are not used anywhere in the codebase. These should be removed to reduce dead code and improve maintainability.

## Fixes

Closes #354 