### PR TITLE
fix: reset DataTable state on Expand All / Collapse All click 

### DIFF
--- a/app/components/ProjectLog/ProjectLog.js
+++ b/app/components/ProjectLog/ProjectLog.js
@@ -78,6 +78,7 @@ function FilterComponent({ filterText, onFilter, onClear }) {
 function projectLog(props) {
   const [filterText, setFilterText] = useState('');
   const [expandAll, setExpandAll] = useState(false);
+  const [tableKey, setTableKey] = useState(0);
   const { feed, error, updates } = props;
   const hasWhatsNewUpdates = updates !== null && !updates.upToDate;
   const [filterWhatsNew, setFilterWhatsNew] = useState(hasWhatsNewUpdates);
@@ -109,10 +110,10 @@ function projectLog(props) {
     return (
       <>
         <div className={styles.headerButton}>
-          <Button variant="outlined" onClick={() => setExpandAll(true)}>
+          <Button variant="outlined" onClick={() => { setExpandAll(true); setTableKey(k => k + 1); }}>
             Expand All
           </Button>
-          <Button variant="outlined" onClick={() => setExpandAll(false)}>
+          <Button variant="outlined" onClick={() => { setExpandAll(false); setTableKey(k => k + 1); }}>
             Collapse All
           </Button>
           {showUpdatesControl}
@@ -158,6 +159,7 @@ function projectLog(props) {
       );
     contents = (
       <DataTable
+        key={tableKey}
         title="Project Log"
         columns={columns}
         data={data}


### PR DESCRIPTION
## Summary

Fixes #359 

- Added `tableKey` state counter to `ProjectLog` component
- Incremented `tableKey` on every **Expand All** / **Collapse All** click
- Added `key={tableKey}` to the `DataTable` component to force a remount on each click

## Problem

Clicking **Expand All** or **Collapse All** a second time had no effect after manually 
toggling individual rows.

## Fix

Introduced a `tableKey` counter that increments on every button click. Passing it as 
`key={tableKey}` to `DataTable` forces React to fully unmount and remount the component, 
wiping its internal row state. The freshly mounted table then evaluates `expandableRowExpanded` 
cleanly for all rows.