### PR TITLE
fix: pass id and name through createStatWrapConfig for cloned projects

### DIFF
--- a/app/utils/DirectoryCloneUtils.js
+++ b/app/utils/DirectoryCloneUtils.js
@@ -51,9 +51,11 @@ export const cloneDirectoryStructure = async (sourceDir, targetDir) => {
  * Creates a new StatWrap configuration folder in the target directory
  *
  * @param {string} targetDir - The target directory where the StatWrap project file will be created
+ * @param {string} [id] - Optional project ID. If not provided, a new UUID will be generated.
+ * @param {string} [name] - Optional project name. Falls back to the directory name if not provided.
  * @returns {Promise<void>}
  */
-export const createStatWrapConfig = async (targetDir) => {
+export const createStatWrapConfig = async (targetDir, id, name) => {
   try {
     // Create the .statwrap base folder
     const configDir = path.join(targetDir, Constants.StatWrapFiles.BASE_FOLDER);
@@ -61,7 +63,7 @@ export const createStatWrapConfig = async (targetDir) => {
 
     const projectConfigFile = path.join(configDir, Constants.StatWrapFiles.PROJECT);
     const projectService = new ProjectService();
-    const projectConfig = projectService.createProjectConfig(null, path.basename(targetDir));
+    const projectConfig = projectService.createProjectConfig(id ?? null, name ?? path.basename(targetDir));
     fs.writeFileSync(projectConfigFile, JSON.stringify(projectConfig));
   } catch (error) {
     throw new Error(`Failed to create StatWrap configuration: ${error.message}`);


### PR DESCRIPTION
## Summary

Fixes #346

Updated `createStatWrapConfig` in `DirectoryCloneUtils.js` to accept and pass through `id` and `name` parameters that were previously silently ignored.

## Problem

```js
// main.dev.js:502 — caller passes id and name
await createStatWrapConfig(path, validationReport.project.id, validationReport.project.name);

// DirectoryCloneUtils.js — function ignored them, generating a new random ID
export const createStatWrapConfig = async (targetDir) => {
  projectService.createProjectConfig(null, path.basename(targetDir));
};
```

This caused the cloned project's `.statwrap-project.json` to have a different ID than the project list entry — confirmed locally by comparing both files after cloning.

## Fix

```js
export const createStatWrapConfig = async (targetDir, id, name) => {
  projectService.createProjectConfig(id ?? null, name ?? path.basename(targetDir));
};
```