### PR TITLE
fix(bug): Cancel "Edit Profile" doesn't discard changes

### DIFF
--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -122,11 +122,11 @@ export default class App extends React.Component {
   }
 
   handleCloseUserProfileDialog() {
-    this.setState({ displayUserProfileDialog: false });
+    this.setState((prevState) => ({ displayUserProfileDialog: false, userProfileDialogKey: prevState.userProfileDialogKey + 1 }));
   }
 
   handleOpenUserProfileDialog() {
-    this.setState({ displayUserProfileDialog: true });
+    this.setState((prevState) => ({ displayUserProfileDialog: true, userProfileDialogKey: prevState.userProfileDialogKey + 1 }));
   }
 
   render() {


### PR DESCRIPTION
## Description
When the user opens the "Edit Profile" dialog (invoked from the upper-right part of the screen), make a change, hit Cancel, re-open the dialog, the changes are still there. The actual issue was that `UserProfileDialog` was not forced re-render on open or close due the same key. I ensured that the `userProfileDialogKey` always change which will cause it to force re-render and discard all old state.

## Fixes
Closes #353

## Video

https://github.com/user-attachments/assets/a7310dbc-c6c4-4d22-98a6-115cfb9555f7

