### PR TITLE
Fix external URL handler signature in main.dev.js

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -128,11 +128,11 @@ const createWindow = async () => {
 
   // Shared handler to take a URL and determine if we should open it in the user's
   // browser (returns true), or if we let electron handle it normally (false).
-  async function handleUrl(url: string) {
+  function handleUrl(url) {
     try {
       const parsedUrl = new URL(url);
       const { protocol } = parsedUrl;
-      if (protocol === "http:" || protocol === "https:") {
+      if (protocol === 'http:' || protocol === 'https:') {
         shell.openExternal(url); // Open in external browser
         return true;
       }


### PR DESCRIPTION
Summary:
Remove accidental TypeScript annotation from JavaScript file and make URL handler synchronous for correct use in setWindowOpenHandler.

Why:
The previous function signature caused JS compile errors, and async returned a Promise where a boolean was expected.

File:
app/main.dev.js