### PR TITLE
fix(ui): update 'Open File' label to 'Open Folder' for folders

### DIFF
--- a/app/components/AssetDetails/AssetDetails.js
+++ b/app/components/AssetDetails/AssetDetails.js
@@ -184,7 +184,9 @@ const assetDetails = (props) => {
             Show in Folder
           </Button>
           <Button size="small" variant="outlined" onClick={handleOpenFile}>
-            Open File
+            {asset.type === Constants.AssetType.DIRECTORY || asset.type === Constants.AssetType.FOLDER
+              ? 'Open Folder'
+              : 'Open File'}
           </Button>
         </Box>
       );


### PR DESCRIPTION
## Description
When the user selects a folder from the Assets tree, the button currently displays "Open File". If the asset is a folder, we want the button to say "Open Folder". This PR implements this by checking if asset type is folder or directory to show "Open Folder".

## Fixes
Closes #381 

## Screenshot
<img width="1287" height="391" alt="image" src="https://github.com/user-attachments/assets/835aa522-0f31-4083-8443-6b3f2d25f95a" />
