### PR TITLE
feat(assets): replace file actions with 'Open URL' for external assets (URL)

### DIFF
--- a/app/components/AssetDetails/AssetDetails.js
+++ b/app/components/AssetDetails/AssetDetails.js
@@ -174,19 +174,22 @@ const assetDetails = (props) => {
     );
   }
 
+  const isURL = asset && asset.type === Constants.AssetType.URL;
+  const isFolder = asset && (asset.type === Constants.AssetType.DIRECTORY || asset.type === Constants.AssetType.FOLDER);
+
   let fileActions = null;
   if (asset) {
     const filePath = asset.uri;
     if (filePath) {
       fileActions = (
         <Box mt={2} mb={2} display="flex" gap={1}>
-          <Button size="small" variant="outlined" onClick={handleShowInFolder}>
-            Show in Folder
-          </Button>
+          {!isURL && (
+            <Button size="small" variant="outlined" onClick={handleShowInFolder}>
+              Show in Folder
+            </Button>
+          )}
           <Button size="small" variant="outlined" onClick={handleOpenFile}>
-            {asset.type === Constants.AssetType.DIRECTORY || asset.type === Constants.AssetType.FOLDER
-              ? 'Open Folder'
-              : 'Open File'}
+            {isURL ? 'Open URL' : (isFolder ? 'Open Folder' : 'Open File')}
           </Button>
         </Box>
       );

--- a/app/components/AssetDetails/AssetDetails.js
+++ b/app/components/AssetDetails/AssetDetails.js
@@ -111,7 +111,7 @@ const assetDetails = (props) => {
     if (asset) {
       const filePath = asset.uri;
       if (filePath) {
-        ipcRenderer.send(Messages.OPEN_FILE_WITH_DEFAULT, filePath);
+        ipcRenderer.send(Messages.OPEN_FILE_WITH_DEFAULT, filePath, isURL);
       }
     }
   };

--- a/app/components/Search/Search.js
+++ b/app/components/Search/Search.js
@@ -58,6 +58,7 @@ import ObjectTypeFilter from './ObjectTypeFilter/ObjectTypeFilter';
 import SettingsContext from '../../contexts/Settings';
 import SearchConfig from '../../constants/search-config';
 import Messages from '../../constants/messages';
+import Constants from '../../constants/constants';
 
 const EMPTY_SEARCH_RESULTS = {
   projects: [],
@@ -1161,7 +1162,7 @@ const ResultItemComponent = ({
                     size="small"
                     variant="outlined"
                     onClick={() => {
-                      ipcRenderer.send(Messages.OPEN_FILE_WITH_DEFAULT, item.fullPath);
+                      ipcRenderer.send(Messages.OPEN_FILE_WITH_DEFAULT, item.fullPath, item.type == Constants.AssetType.URL);
                     }}
                   >
                     Open File

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -1054,7 +1054,7 @@ ipcMain.on(Messages.SHOW_ITEM_IN_FOLDER, (event, fullPath) => {
 });
 
 // Handler to open file with default application
-ipcMain.on(Messages.OPEN_FILE_WITH_DEFAULT, (event, fullPath, isURL) => {
+ipcMain.on(Messages.OPEN_FILE_WITH_DEFAULT, (event, fullPath, isURL = false) => {
   const { shell } = require('electron');
   if (isURL) {
     shell.openExternal(fullPath);

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -1054,9 +1054,13 @@ ipcMain.on(Messages.SHOW_ITEM_IN_FOLDER, (event, fullPath) => {
 });
 
 // Handler to open file with default application
-ipcMain.on(Messages.OPEN_FILE_WITH_DEFAULT, (event, fullPath) => {
+ipcMain.on(Messages.OPEN_FILE_WITH_DEFAULT, (event, fullPath, isURL) => {
   const { shell } = require('electron');
-  shell.openPath(fullPath);
+  if (isURL) {
+    shell.openExternal(fullPath);
+  } else {
+    shell.openPath(fullPath);
+  }
 });
 
 /**


### PR DESCRIPTION
## Description
For external resources, if the user selects an item from the Assets tree, it displays the default "Show in Folder" and "Open File" buttons. These are not applicable if the asset is a URL. This PR implements this, it shows `OPEN URL` for external assets if the asset is a URL.

## Fixes
Closes #382

## Screenshot
<img width="846" height="370" alt="image" src="https://github.com/user-attachments/assets/cae8fb82-a0ed-4269-8acb-26398ce62031" />
