### PR TITLE
Added Confirming card before deleting the person in the table's view

### DIFF
--- a/app/components/People/PeopleTable/PeopleTable.css
+++ b/app/components/People/PeopleTable/PeopleTable.css
@@ -1,2 +1,3 @@
-.container {
+.title {
+  color: white;
 }

--- a/app/components/People/PeopleTable/PeopleTable.js
+++ b/app/components/People/PeopleTable/PeopleTable.js
@@ -1,6 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { IconButton } from '@mui/material';
+import {
+  IconButton,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Button,
+} from '@mui/material';
 import { FaTrash, FaEdit } from 'react-icons/fa';
 import styled from 'styled-components';
 import DataTable from 'react-data-table-component';
@@ -56,6 +64,18 @@ function FilterComponent({ filterText, onFilter, onClear }) {
 function peopleTable(props) {
   const { mode, list, onEdit, onDelete } = props;
   const [filterText, setFilterText] = React.useState('');
+  const [personToDelete, setPersonToDelete] = React.useState(null);
+
+  const closeDeleteConfirm = () => {
+    setPersonToDelete(null);
+  };
+
+  const confirmDeletePersonHandler = () => {
+    if (onDelete && personToDelete && personToDelete.id) {
+      onDelete(personToDelete);
+    }
+    closeDeleteConfirm();
+  };
 
   const subHeaderComponentMemo = React.useMemo(() => {
     const handleClear = () => {
@@ -120,8 +140,8 @@ function peopleTable(props) {
         return (
           <IconButton
             onClick={() => {
-              if (onDelete && record && record.id) {
-                onDelete(record);
+              if (record && record.id) {
+                setPersonToDelete(record);
               }
             }}
             aria-label="delete"
@@ -170,7 +190,27 @@ function peopleTable(props) {
     );
   }
 
-  return <div className={styles.container}>{contents}</div>;
+  return (
+    <div className={styles.container}>
+      {contents}
+      <Dialog open={!!personToDelete} onClose={closeDeleteConfirm}>
+        <DialogTitle classes={{ root: styles.title }}>Remove Person</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to remove{' '}
+            <strong>{personToDelete ? GeneralUtil.formatName(personToDelete.name) : ''}</strong>{' '}
+            from this project?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeDeleteConfirm}>Cancel</Button>
+          <Button onClick={confirmDeletePersonHandler} color="error">
+            Remove
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
 }
 
 peopleTable.propTypes = {


### PR DESCRIPTION
### Description:
Currently in the People's section , when the added people are in the cards' view and we click on the delete option , a card pops out for our confirmation but when the same added people are in the rows view , and click on the delete icon , it directly deletes the person  without confirming through the cards.
This PR fixes this by adding the confirmation cards.

### Screenshots: 
This cards pops out in the Cards view only when we click on the delete icon but not for the same thing in the Rows' view.
<img width="674" height="431" alt="1" src="https://github.com/user-attachments/assets/71599b2b-7685-4e11-b90e-2d3dbbdce6ff" />

After this PR , this confirmation cards also appear if you click on the Delete icon in the Rows'view :
<img width="819" height="488" alt="2" src="https://github.com/user-attachments/assets/6b569f1a-2941-4c9c-9a2c-ce8b8b2e9ca0" />


