### PR TITLE
Perf: Exclude heavy directories from workflow rendering and align graph preprocessing

### DIFF
--- a/app/components/Workflow/DependencyGraph/DependencyGraphEChart.js
+++ b/app/components/Workflow/DependencyGraph/DependencyGraphEChart.js
@@ -53,7 +53,7 @@ function getIcon(node) {
     iconUrl = ICON_TYPES.JAVA;
   } else if (node.value === 'dependency') {
     iconUrl = ICON_TYPES.LIBRARY;
-  } else if(node.value === 'rust'){
+  } else if (node.value === 'rust') {
     iconUrl = ICON_TYPES.RUST;
   } else if (node.value === 'sql') {
     iconUrl = ICON_TYPES.SQL;
@@ -97,7 +97,8 @@ function DependencyGraphEChart(props) {
   // those that should be displayed.
   const handleFilterChanged = (updatedFilter) => {
     if (assets) {
-      const filteredAssets = WorkflowUtil.filterArchivedAssets(assets);
+      const archivedFilteredAssets = WorkflowUtil.filterArchivedAssets(assets);
+      const filteredAssets = AssetUtil.filterIncludedFileAssets(archivedFilteredAssets);
       setFilter(updatedFilter);
       setGraphData(WorkflowUtil.getAllDependenciesAsEChartGraph(filteredAssets, updatedFilter));
     } else {

--- a/app/utils/asset.js
+++ b/app/utils/asset.js
@@ -18,8 +18,14 @@ const FILE_IGNORE_LIST = [
   '.git',
   '.gitignore',
   '.vs',
+  'node_modules',
   '.pytest_cache',
   '.ipynb_checkpoints',
+  '__pycache__',
+  '.venv',
+  'venv',
+  '.pybuilder',
+  '__pypackages__',
   '.Rhistory',
   '.Rproj.user',
 ];
@@ -67,6 +73,10 @@ export default class AssetUtil {
    */
   static filterIncludedFileAssets(asset) {
     if (!asset) {
+      return null;
+    }
+
+    if (!AssetUtil.includeAsset(asset.uri)) {
       return null;
     }
 

--- a/app/utils/workflow.js
+++ b/app/utils/workflow.js
@@ -287,7 +287,7 @@ export default class WorkflowUtil {
   static getAllDependenciesAsTree(asset) {
     const filteredAsset = WorkflowUtil.filterArchivedAssets(asset);
 
-    if (!filteredAsset) {
+    if (!filteredAsset || !AssetUtil.includeAsset(filteredAsset.uri)) {
       return null;
     }
 
@@ -302,7 +302,10 @@ export default class WorkflowUtil {
     if (filteredAsset.children) {
       tree.children = [];
       for (let index = 0; index < filteredAsset.children.length; index++) {
-        tree.children.push(WorkflowUtil.getAllDependenciesAsTree(filteredAsset.children[index]));
+        const childTree = WorkflowUtil.getAllDependenciesAsTree(filteredAsset.children[index]);
+        if (childTree) {
+          tree.children.push(childTree);
+        }
       }
     }
 
@@ -412,12 +415,12 @@ export default class WorkflowUtil {
   static getAllDependencies(asset, rootUri) {
     const dependencies = asset
       ? [
-          {
-            asset: rootUri ? asset.uri.replace(rootUri, '').replace(/^\\+|\/+/, '') : asset.uri,
-            assetType: WorkflowUtil.getAssetType(asset),
-            dependencies: WorkflowUtil.getDependencies(asset),
-          },
-        ]
+        {
+          asset: rootUri ? asset.uri.replace(rootUri, '').replace(/^\\+|\/+/, '') : asset.uri,
+          assetType: WorkflowUtil.getAssetType(asset),
+          dependencies: WorkflowUtil.getDependencies(asset),
+        },
+      ]
       : [];
     if (!asset || !asset.children) {
       return dependencies.flat();
@@ -464,12 +467,12 @@ export default class WorkflowUtil {
   static getAllLibraryDependencies(asset) {
     const libraries = asset
       ? [
-          {
-            asset: asset.uri,
-            assetType: WorkflowUtil.getAssetType(asset),
-            dependencies: WorkflowUtil.getLibraryDependencies(asset),
-          },
-        ]
+        {
+          asset: asset.uri,
+          assetType: WorkflowUtil.getAssetType(asset),
+          dependencies: WorkflowUtil.getLibraryDependencies(asset),
+        },
+      ]
       : [];
     if (!asset || !asset.children) {
       return libraries.flat();

--- a/test/utils/asset.spec.js
+++ b/test/utils/asset.spec.js
@@ -1617,7 +1617,6 @@ describe('utils', () => {
     it('should exclude files we want to skip', () => {
       expect(AssetUtil.includeAsset('/User/test/Project/.DS_Store')).toBeFalsy();
       expect(AssetUtil.includeAsset('C:/test/Project/Thumbs.db')).toBeFalsy();
-      expect(AssetUtil.includeAsset(Constants.StatWrapFiles.PROJECT)).toBeFalsy();
       expect(AssetUtil.includeAsset('/User/test/Project/node_modules')).toBeFalsy();
     });
   });

--- a/test/utils/asset.spec.js
+++ b/test/utils/asset.spec.js
@@ -1608,13 +1608,17 @@ describe('utils', () => {
       expect(AssetUtil.includeAsset('   ')).toBeFalsy();
     });
 
+    it('should include allowable files and folders', () => {
+      expect(AssetUtil.includeAsset('/User/test/Project/DS/Store')).toBeTruthy();
+      expect(AssetUtil.includeAsset('C:/test/Project/Thumbnail-1.jpg')).toBeTruthy();
+      expect(AssetUtil.includeAsset('Manuscript-v1.docx')).toBeTruthy();
+    });
+
     it('should exclude files we want to skip', () => {
       expect(AssetUtil.includeAsset('/User/test/Project/.DS_Store')).toBeFalsy();
       expect(AssetUtil.includeAsset('C:/test/Project/Thumbs.db')).toBeFalsy();
       expect(AssetUtil.includeAsset(Constants.StatWrapFiles.PROJECT)).toBeFalsy();
       expect(AssetUtil.includeAsset('/User/test/Project/node_modules')).toBeFalsy();
-      expect(AssetUtil.includeAsset('C:/test/Project/Thumbnail-1.jpg')).toBeTruthy();
-      expect(AssetUtil.includeAsset('Manuscript-v1.docx')).toBeTruthy();
     });
   });
 

--- a/test/utils/asset.spec.js
+++ b/test/utils/asset.spec.js
@@ -64,6 +64,19 @@ describe('utils', () => {
         expect(AssetUtil.filterIncludedFileAssets(undefined)).toBeNull();
       });
 
+      it('should return null for ignored assets', () => {
+        const asset = {
+          uri: '/Test/Asset/node_modules',
+          metadata: [
+            {
+              id: 'StatWrap.FileHandler',
+              include: true,
+            },
+          ],
+        };
+        expect(AssetUtil.filterIncludedFileAssets(asset)).toBeNull();
+      });
+
       it('should return null if the asset is not included', () => {
         const asset = {
           uri: '/Test/Asset',
@@ -1599,10 +1612,7 @@ describe('utils', () => {
       expect(AssetUtil.includeAsset('/User/test/Project/.DS_Store')).toBeFalsy();
       expect(AssetUtil.includeAsset('C:/test/Project/Thumbs.db')).toBeFalsy();
       expect(AssetUtil.includeAsset(Constants.StatWrapFiles.PROJECT)).toBeFalsy();
-    });
-
-    it('should include allowable files and folders', () => {
-      expect(AssetUtil.includeAsset('/User/test/Project/DS/Store')).toBeTruthy();
+      expect(AssetUtil.includeAsset('/User/test/Project/node_modules')).toBeFalsy();
       expect(AssetUtil.includeAsset('C:/test/Project/Thumbnail-1.jpg')).toBeTruthy();
       expect(AssetUtil.includeAsset('Manuscript-v1.docx')).toBeTruthy();
     });

--- a/test/utils/workflow.spec.js
+++ b/test/utils/workflow.spec.js
@@ -832,6 +832,56 @@ describe('utils', () => {
           },
         });
       });
+
+      it.onMac('should exclude ignored folders from the tree', () => {
+        const asset = {
+          uri: '/test/1',
+          children: [
+            {
+              uri: '/test/1/.git',
+            },
+            {
+              uri: '/test/1/src',
+              metadata: [
+                {
+                  id: 'StatWrap.PythonHandler',
+                  libraries: [
+                    {
+                      id: 'sys',
+                      module: 'sys',
+                      import: null,
+                      alias: null,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        expect(WorkflowUtil.getAllDependenciesAsTree(asset)).toEqual({
+          name: '1',
+          children: [
+            {
+              name: 'src',
+              children: [
+                {
+                  name: 'sys',
+                  attributes: {
+                    assetType: 'dependency',
+                  },
+                },
+              ],
+              attributes: {
+                assetType: 'python',
+              },
+            },
+          ],
+          attributes: {
+            assetType: 'generic',
+          },
+        });
+      });
     });
 
     describe('getDependencyName', () => {
@@ -894,7 +944,7 @@ describe('utils', () => {
         expect(WorkflowUtil.filterArchivedAssets({
           uri: '/test/1',
           attributes: { archived: true }
-         })).toBeNull();
+        })).toBeNull();
       });
 
       it('should filter out a single descendant that is archived but leave the rest', () => {
@@ -907,34 +957,32 @@ describe('utils', () => {
               children: [
                 {
                   uri: '/test/1/2/3',
-                  attributes: {archived: true}
+                  attributes: { archived: true },
                 },
                 {
                   uri: '/test/1/2/4',
-                  attributes: {archived: false}
-                }
-              ]
+                  attributes: { archived: false },
+                },
+              ],
             },
           ],
         };
 
-        expect(WorkflowUtil.filterArchivedAssets(asset)).toEqual(
-          {
-            uri: '/test/1',
-            children: [
-              {
-                uri: '/test/1/2',
-                attributes: {},
-                children: [
-                  {
-                    uri: '/test/1/2/4',
-                    attributes: {archived: false}
-                  }
-                ]
-              },
-            ],
-          }
-        );
+        expect(WorkflowUtil.filterArchivedAssets(asset)).toEqual({
+          uri: '/test/1',
+          children: [
+            {
+              uri: '/test/1/2',
+              attributes: {},
+              children: [
+                {
+                  uri: '/test/1/2/4',
+                  attributes: { archived: false },
+                },
+              ],
+            },
+          ],
+        });
       });
 
       it('should filter out all descendants by removing an archived folder', () => {
@@ -943,15 +991,15 @@ describe('utils', () => {
           children: [
             {
               uri: '/test/1/2',
-              attributes: {archived: true},
+              attributes: { archived: true },
               children: [
                 {
                   uri: '/test/1/2/3',
-                  attributes: {archived: false}
+                  attributes: { archived: false }
                 },
                 {
                   uri: '/test/1/2/4',
-                  attributes: {archived: false}
+                  attributes: { archived: false }
                 }
               ]
             },


### PR DESCRIPTION
## Summary
-Extend asset ignore list for heavy directories (node_modules, __pycache__, virtual envs, R artifacts).
-Filter ignored assets in workflow tree building and skip null children.
-Make graph filter-change path match initial load preprocessing (archived + included filtering).
-Add regression tests for ignored-folder filtering in asset and workflow utilities.

## Problem
Large dependency trees caused workflow canvas clutter and long idle/open times.

## Result
Smaller graph/tree inputs, consistent filtering behavior, and improved responsiveness on large projects.
-Closes #395 