### PR TITLE
Fixing Project Log Name issue

### DIFF
--- a/app/components/ProjectLog/GeneralAction/GeneralAction.js
+++ b/app/components/ProjectLog/GeneralAction/GeneralAction.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
 import gfm from 'remark-gfm';
 import Constants from '../../../constants/constants';
+import GeneralUtil from '../../../utils/general';
 import styles from './GeneralAction.css';
 
 const CollapsibleMarkdown = ({ content }) => {
@@ -33,11 +34,20 @@ CollapsibleMarkdown.propTypes = {
   content: PropTypes.string,
 };
 
-const formatValue = (value) => {
+const formatValue = (key, value) => {
   if (Array.isArray(value)) {
     return value.length > 0 ? value.join(', ') : <span className={styles.emptyContent}>(Empty)</span>;
   }
   if (typeof value === 'object' && value !== null) {
+    // Render person-style names as readable text instead of raw JSON.
+    if (
+      key === 'name' &&
+      (Object.prototype.hasOwnProperty.call(value, 'first') ||
+        Object.prototype.hasOwnProperty.call(value, 'last'))
+    ) {
+      return GeneralUtil.formatName(value);
+    }
+
     if (value.contentType === Constants.DescriptionContentType.MARKDOWN) {
       if (!value.content) {
         return <span className={styles.emptyContent}>(Empty description)</span>;
@@ -52,7 +62,7 @@ const formatValue = (value) => {
 const generateRow = (key, value) => {
   return (
     <div key={key} className={styles.row}>
-      <span className={styles.label}>{key}:</span> {formatValue(value)}
+      <span className={styles.label}>{key}:</span> {formatValue(key, value)}
     </div>
   );
 };


### PR DESCRIPTION
### Description 
Issue is very small in the Project Log , when we update person details and sees its logs , we see that Name is shown directly with raw json.
This PR fixes this and shows the name in human readable form.

### Screenshots:
This is the current Name shown in the Project's Log:
<img width="692" height="151" alt="11" src="https://github.com/user-attachments/assets/3f2d7bf3-bcb1-4410-8542-636c7e7302f8" />

After changing this , Now we see clearly Name as readable form.
<img width="898" height="204" alt="22" src="https://github.com/user-attachments/assets/85c65071-33c7-4313-b299-489810eb93d0" />

