### PR TITLE
chore: enforce curly braces on all inline control statements

### DIFF
--- a/app/components/Project/Assets/Assets.js
+++ b/app/components/Project/Assets/Assets.js
@@ -130,7 +130,7 @@ const assetsComponent = (props) => {
       // Collecting all sensitive marked files
       const sensitiveFiles = [];
       const collectSensitiveFiles = (asset) => {
-        if (!asset) return;
+        if (!asset) {return;}
         if (asset.type === Constants.AssetType.FILE && asset.attributes && asset.attributes.sensitive) {
           sensitiveFiles.push(asset.uri);
         }

--- a/app/components/Project/Project.js
+++ b/app/components/Project/Project.js
@@ -437,7 +437,7 @@ class Project extends Component<Props> {
 
   handleConfirmUnarchive = (alsoDescendants) => {
     const { pendingUnarchive } = this.state;
-    if (!pendingUnarchive) return;
+    if (!pendingUnarchive) {return;}
 
     this.performAssetAttributeUpdate(
       pendingUnarchive.assetUri,

--- a/app/components/Search/Search.js
+++ b/app/components/Search/Search.js
@@ -259,7 +259,7 @@ const Search = (props) => {
       ipcRenderer.removeListener(Messages.SEARCH_GET_SUGGESTIONS_RESPONSE, handleSearchSuggestionsResponse);
 
       document.removeEventListener('keydown', handleKeyDown);
-      if (searchTimeout) clearTimeout(searchTimeout);
+      if (searchTimeout) {clearTimeout(searchTimeout);}
     };
   }, []);
 
@@ -436,7 +436,7 @@ const Search = (props) => {
   };
 
   const highlightText = (text, query) => {
-    if (!query || !text || typeof text !== 'string') return text;
+    if (!query || !text || typeof text !== 'string') {return text;}
 
     try {
       const regex = new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
@@ -897,13 +897,13 @@ const ResultsList = ({
   );
 };
 const formatPersonName = (name) => {
-  if (!name) return '';
-  if (typeof name === 'string') return name;
+  if (!name) {return '';}
+  if (typeof name === 'string') {return name;}
 
   const parts = [];
-  if (name.first) parts.push(name.first);
-  if (name.middle) parts.push(name.middle);
-  if (name.last) parts.push(name.last);
+  if (name.first) {parts.push(name.first);}
+  if (name.middle) {parts.push(name.middle);}
+  if (name.last) {parts.push(name.last);}
 
   return parts.join(' ').trim();
 };
@@ -944,19 +944,19 @@ const ResultItemComponent = ({
   };
 
   const getRelevanceColor = (relevance) => {
-    if (relevance >= 80) return 'success';
-    if (relevance >= 60) return 'warning';
-    if (relevance >= 40) return 'info';
+    if (relevance >= 80) {return 'success';}
+    if (relevance >= 60) {return 'warning';}
+    if (relevance >= 40) {return 'info';}
     return 'default';
   };
 
   const renderTags = () => {
-    if (!item.tags || (!Array.isArray(item.tags) && typeof item.tags !== 'string')) return null;
+    if (!item.tags || (!Array.isArray(item.tags) && typeof item.tags !== 'string')) {return null;}
 
     const tagArray = Array.isArray(item.tags)
       ? item.tags
       : item.tags.split(' ').filter((t) => t.trim());
-    if (tagArray.length === 0) return null;
+    if (tagArray.length === 0) {return null;}
 
     return (
       <Box mt={1} display="flex" gap={0.5} flexWrap="wrap">

--- a/app/components/Search/SearchSettings/SearchSettings.js
+++ b/app/components/Search/SearchSettings/SearchSettings.js
@@ -137,7 +137,7 @@ const searchSettings = (props) => {
 
   const handleImportIndex = (event) => {
     const file = event.target.files[0];
-    if (!file) return;
+    if (!file) {return;}
 
     const reader = new FileReader();
     reader.onload = (e) => {

--- a/app/containers/CreateProjectDialog/CreateProjectDialog.js
+++ b/app/containers/CreateProjectDialog/CreateProjectDialog.js
@@ -149,7 +149,7 @@ class CreateProjectDialog extends Component {
            targetBaseDir && targetBaseDir !== '' &&
            name && name !== '';
 
-    if (!hasRequiredFields) return { isValid: false, errorMessage: null };
+    if (!hasRequiredFields) {return { isValid: false, errorMessage: null };}
 
     // Normalize paths to handle different path separators
     const normalizedSource = sourceDir.replace(/\\/g, '/');

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -221,7 +221,7 @@ app.whenReady().then(createWindow);
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) createWindow();
+  if (mainWindow === null) {createWindow();}
 });
 
 app.on('before-quit', () => {

--- a/app/services/SearchService.js
+++ b/app/services/SearchService.js
@@ -490,7 +490,7 @@ class SearchService {
 
     // Check for path changes
     const projectsToUpdate = currentProjects.filter((p) => {
-      if (!indexedProjectIds.has(p.id)) return false;
+      if (!indexedProjectIds.has(p.id)) {return false;}
 
       const indexedProject = this.indexedProjectsMap.get(p.id);
       return indexedProject.path !== p.path;
@@ -1014,7 +1014,7 @@ class SearchService {
   }
 
   async indexPerson(person, project) {
-    if (!person || !person.id) return;
+    if (!person || !person.id) {return;}
 
     const searchableContent = [
       this.formatPersonName(person.name),
@@ -1056,7 +1056,7 @@ class SearchService {
   }
 
   async indexNote(note, project, entityType, entityName) {
-    if (!note || !note.content) return;
+    if (!note || !note.content) {return;}
 
     const docId = this.generateDocumentId('note', note.id || Date.now(), entityType);
 
@@ -1085,7 +1085,7 @@ class SearchService {
   }
 
   async indexAssetGroup(group, project) {
-    if (!group || !group.id) return;
+    if (!group || !group.id) {return;}
 
     const searchableContent = [
       group.name || '',
@@ -1117,14 +1117,14 @@ class SearchService {
   }
 
   formatPersonName(name) {
-    if (!name) return '';
+    if (!name) {return '';}
 
-    if (typeof name === 'string') return name;
+    if (typeof name === 'string') {return name;}
 
     const parts = [];
-    if (name.first) parts.push(name.first);
-    if (name.middle) parts.push(name.middle);
-    if (name.last) parts.push(name.last);
+    if (name.first) {parts.push(name.first);}
+    if (name.middle) {parts.push(name.middle);}
+    if (name.last) {parts.push(name.last);}
 
     return parts.join(' ').trim();
   }
@@ -1514,7 +1514,7 @@ class SearchService {
    * Calculate proximity score (how close query terms appear to each other)
    */
   calculateProximityScore(content, queryTerms) {
-    if (queryTerms.length < 2) return 0;
+    if (queryTerms.length < 2) {return 0;}
 
     let proximityScore = 0;
     const positions = {};
@@ -1940,7 +1940,7 @@ class SearchService {
 
   getFromCache(key) {
     const cached = this.resultCache.get(key);
-    if (!cached) return null;
+    if (!cached) {return null;}
 
     if (Date.now() - cached.timestamp > this.cacheTTL) {
       this.resultCache.delete(key);

--- a/app/services/assets/handlers/r.js
+++ b/app/services/assets/handlers/r.js
@@ -512,7 +512,7 @@ export default class RHandler extends BaseCodeHandler {
 
     for (let line of lines) {
       line = line.trim();
-      if (!line) continue;
+      if (!line) {continue;}
 
       // new list item
       if (line.startsWith('-')) {
@@ -520,7 +520,7 @@ export default class RHandler extends BaseCodeHandler {
         if (val === '') {
         } else if (val.startsWith('name:')) {
           const parsedName = val.replace('name:', '').trim().replace(/^['"]|['"]$/g, '');
-          if (parsedName) authors.push(parsedName);
+          if (parsedName) {authors.push(parsedName);}
         } else if (val.includes(':')) {
           // grabs the value of the first attribute
         } else {
@@ -531,7 +531,7 @@ export default class RHandler extends BaseCodeHandler {
         // Not starting with '-', its a property of an object in a list
         if (line.startsWith('name:')) {
           const parsedName = line.replace('name:', '').trim().replace(/^['"]|['"]$/g, '');
-          if (parsedName) authors.push(parsedName);
+          if (parsedName) {authors.push(parsedName);}
         }
       }
     }

--- a/app/utils/project.js
+++ b/app/utils/project.js
@@ -119,9 +119,9 @@ export default class ProjectUtil {
         return null;
       }
       const attrs = [];
-      if (x.attributes.archived) attrs.push('archived');
-      if (x.attributes.entrypoint) attrs.push('entrypoint');
-      if (x.attributes.sensitive) attrs.push('sensitive');
+      if (x.attributes.archived) {attrs.push('archived');}
+      if (x.attributes.entrypoint) {attrs.push('entrypoint');}
+      if (x.attributes.sensitive) {attrs.push('sensitive');}
       return attrs.length > 0 ? attrs : null;
     };
     ProjectUtil._processAssetAndDescendantsForFilter(assets, attributeFilter, attributeFunc);

--- a/app/utils/workflow.js
+++ b/app/utils/workflow.js
@@ -187,7 +187,7 @@ export default class WorkflowUtil {
     // Create a map of relative URIs to assets for faster lookup
     const assetMap = new Map();
     const buildAssetMap = (asset) => {
-      if (!asset) return;
+      if (!asset) {return;}
       const relativeUri = filteredAsset.uri
         ? asset.uri.replace(filteredAsset.uri, '').replace(/^\\+|\/+/, '')
         : asset.uri;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ module.exports = {
     'jest/no-standalone-expect': 0,
     'jest/expect-expect': 0,
     'no-unused-vars': 0,
+    curly: ['error', 'all'],
   },
   settings: {
     'import/resolver': {

--- a/internals/scripts/CheckNativeDep.js
+++ b/internals/scripts/CheckNativeDep.js
@@ -5,7 +5,7 @@ import { execSync } from 'child_process';
 import { dependencies } from '../../package.json';
 
 (() => {
-  if (!dependencies) return;
+  if (!dependencies) {return;}
   const dependenciesKeys = Object.keys(dependencies);
   const nativeDeps = fs
     .readdirSync('node_modules')


### PR DESCRIPTION
## Summary

Enables the ESLint curly rule to strictly enforce braces across all control statements (if/else, loops, etc.)
This standardizes the project's code style and prevents future logic errors from dangling statements. 
All existing non compliant files (11 files) were automatically formatted using `eslint --fix`